### PR TITLE
DATAAPI-1: possibility to limit watch fields for record updates when queueing is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Additional _optional_ annotation options at the _object_ level are:
 * `dataApiUpsertExcludeFields`: Fields **not** to accept in POST/PUT requests (defaults to `dataApiExcludeFields`)
 * `dataApiFilterFields`: Fields to allow as simple filters for paginated GET requests (defaults to foreign keys, boolean and enum fields)
 * `dataApiAllowIdInsert`: Whether or not to allow the ID field to be set during a POST operation to create a new record
+* `dataApiQueueRelevantFields`: Fields that are relevant to trigger a record update to be queued. If not used, then any data change will be queued. If used then only the specified fields will be examined and in case of atomic-changes for the queue only the relevant field changes will be included in the queue item. Inserts and deletes are always queued, only during updates this annotation is evaluated.
 
 ### Property annotations
 

--- a/services/DataApiConfigurationService.cfc
+++ b/services/DataApiConfigurationService.cfc
@@ -140,6 +140,18 @@ component {
 			return entities[ args.entity ].upsertFields ?: [];
 		} );
 	}
+	
+	public array function getRelevantQueueFields( required string entity, string namespace=_getDataApiNamespace() ) {
+		var args     = arguments;
+		var cacheKey = "getRelevantQueueFields" & args.namespace & args.entity;
+		
+		return _simpleLocalCache( cacheKey, function(){
+			var objectName = getEntityObject( args.entity, args.namespace );
+			var fields     = $getPresideObjectService().getObjectAttribute( objectName, "dataApiQueueRelevantFields#_getNamespaceWithSeparator( args.namespace )#" );
+			
+			return listToArray( fields );
+		} );
+	}
 
 	public struct function getFieldSettings( required string entity, string namespace=_getDataApiNamespace() ) {
 		var args     = arguments;


### PR DESCRIPTION
Beside the implementation and support of that new annotation I made a slight change in the queueUpdate method for better performance. In particular the order of 2 loops has been switched such that the check for the object exists only happens once and not for each subscriber.