### PR TITLE
Add ignore default filter function

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Additional _optional_ annotation options at the _object_ level are:
 * `dataApiQueue`: Specific queue name for this object
 * `dataApiSortOrder`: Sort order for paginated results. Default is date last modified ascending.
 * `dataApiSavedFilters`: Comma-separated list of saved filters to apply to all requests to this object (e.g. only return active records)
+* `dataApiIgnoreDefaultFilters`: Comma-separated list of ignore default filters to apply to all requests to this object
 * `dataApiVerbs`: Supported REST HTTP Verbs. If not supplied, all verbs and operations are supported (i.e. GET, POST, PUT and DELETE)
 * `dataApiFields`: Fields to return in GET requests (defaults to all non-excluded fields)
 * `dataApiUpsertFields`: Fields to accept in POST/PUT request (defaults to `dataApiFields`)
@@ -265,7 +266,7 @@ or
  */
 ```
 
-#### Skip a data api queue: 
+#### Skip a data api queue:
 
 To prevent data api queue to be created when you insert data into an object, you can set `skipDataApiQueue = true` as argument in the `insertData` function. For example:
 

--- a/services/DataApiConfigurationService.cfc
+++ b/services/DataApiConfigurationService.cfc
@@ -93,6 +93,19 @@ component {
 		} );
 	}
 
+	public array function getIgnoreDefaultFilters( required string entity, string namespace=_getDataApiNamespace() ) {
+		var args     = arguments;
+		var cacheKey = "getIgnoreDefaultFilters" & args.namespace & args.entity;
+
+		return _simpleLocalCache( cacheKey, function(){
+			var objectName           = getEntityObject( args.entity, args.namespace );
+			var poService            = $getPresideObjectService();
+			var ignoreDefaultFilters = poService.getObjectAttribute( objectName, "dataApiIgnoreDefaultFilters#_getNamespaceWithSeparator( args.namespace )#" );
+
+			return listToArray( trim( ignoreDefaultFilters ) );
+		} );
+	}
+
 	public array function getSelectFields( required string entity, boolean aliases=false ) {
 		var args     = arguments;
 		var cacheKey = "getSelectFields" & _getDataApiNamespace() & args.entity & args.aliases;

--- a/services/DataApiService.cfc
+++ b/services/DataApiService.cfc
@@ -266,6 +266,7 @@ component {
 		args.fromVersionTable        = false;
 		args.orderBy                 = configService.getSelectSortOrder( arguments.entity );
 		args.savedFilters            = configService.getSavedFilters( arguments.entity );
+		args.ignoreDefaultFilters    = configService.getIgnoreDefaultFilters( arguments.entity );
 		args.allowDraftVersions      = false;
 		args.autoGroupBy             = true;
 		args.distinct                = true;


### PR DESCRIPTION
Add additional object attribute to allow API ignore default filter. This is helpful for soft deleted record is visible and accessible by the API to update.