### PR TITLE
Cache the processed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 npm-debug.log
 /tests/server*.json
 /modules
+.vscode/settings.json

--- a/interceptors/DataApiInterceptors.cfc
+++ b/interceptors/DataApiInterceptors.cfc
@@ -165,4 +165,21 @@ component extends="coldbox.system.Interceptor" {
 
 		dataApiQueueService.queueInsert( argumentCollection=interceptData );
 	}
+
+
+
+	public void function onCreateSelectDataCacheKey( event, interceptData ) {
+		if ( !_applicationLoaded ) return;
+
+		var objectName = interceptData.objectName ?: "";
+		event.setValue( name="cacheKey", value=interceptData.cacheKey ?: "", private=true );
+		event.setValue( name="getFromCache", value=false, private=true );
+
+		var cachedResult = queryCache.get( interceptData.cacheKey );
+			//writeDump(interceptData);abort;
+		if ( !IsNull( local.cachedResult ) ) {
+				event.setValue( name="getFromCache", value=true, private=true );
+		}
+	}
+
 }

--- a/interceptors/DataApiInterceptors.cfc
+++ b/interceptors/DataApiInterceptors.cfc
@@ -175,6 +175,7 @@ component extends="coldbox.system.Interceptor" {
 		var objectName = interceptData.objectName ?: "";
 		event.setValue( name="cacheKey", value=interceptData.cacheKey ?: "", private=true );
 		event.setValue( name="getFromCache", value=false, private=true );
+		event.setValue( name="#objectName#_useCache", value=true, private=true );
 
 		var cachedResult = queryCache.get( interceptData.cacheKey );
 		if ( !IsNull( local.cachedResult ) ) {

--- a/interceptors/DataApiInterceptors.cfc
+++ b/interceptors/DataApiInterceptors.cfc
@@ -4,6 +4,7 @@ component extends="coldbox.system.Interceptor" {
 	property name="dataApiQueueService"         inject="delayedInjector:dataApiQueueService";
 	property name="dataApiConfigurationService" inject="delayedInjector:dataApiConfigurationService";
 	property name="interceptorService"          inject="coldbox:InterceptorService";
+	property name="queryCache"                         inject="cachebox:DefaultQueryCache";
 
 	variables._applicationLoaded = false;
 
@@ -176,9 +177,8 @@ component extends="coldbox.system.Interceptor" {
 		event.setValue( name="getFromCache", value=false, private=true );
 
 		var cachedResult = queryCache.get( interceptData.cacheKey );
-			//writeDump(interceptData);abort;
 		if ( !IsNull( local.cachedResult ) ) {
-				event.setValue( name="getFromCache", value=true, private=true );
+			event.setValue( name="getFromCache", value=true, private=true );
 		}
 	}
 

--- a/services/DataApiService.cfc
+++ b/services/DataApiService.cfc
@@ -282,14 +282,14 @@ component {
 
 		var event               = $getRequestContext();
 		var cacheKey =		event.getValue( name="cacheKey", default ="", private=true );
+		var useCache =		event.getValue( name="#objectName#_useCache", default =false, private=true );
 		var cachedProcessed=		queryCache.get( "dataApi_#cacheKey#" );
 
-		var getFromCache =		false;
-		if ( !IsNull( local.cachedProcessed ) ) {
-			getFromCache = true
+		if ( useCache && !IsNull( local.cachedProcessed ) ) {
+			useCache = true
 		}
 
-		getFromCache = getFromCache && event.getValue( name="getFromCache", default =false, private=true );
+		var getFromCache = useCache && event.getValue( name="getFromCache", default =false, private=true );
 
 		if(getFromCache){
 			var processed =	local.cachedProcessed;

--- a/services/DataApiService.cfc
+++ b/services/DataApiService.cfc
@@ -279,12 +279,28 @@ component {
 		}
 
 		var records   = dao.selectData( argumentCollection=args );
-		var processed = [];
 
-		for( var record in records ) {
-			processed.append( _processFields( record, fieldSettings ) );
+		var event               = $getRequestContext();
+		var cacheKey =		event.getValue( name="cacheKey", default ="", private=true );
+		var cachedProcessed=		queryCache.get( "dataApi_#cacheKey#" );
+
+		var getFromCache =		false;
+		if ( !IsNull( local.cachedProcessed ) ) {
+			getFromCache = true
 		}
-		$announceInterception( "postDataApiSelectData#namespace#", { selectDataArgs=args, entity=arguments.entity, data=processed } );
+
+		getFromCache = getFromCache && event.getValue( name="getFromCache", default =false, private=true );
+
+		if(getFromCache){
+			var processed =	local.cachedProcessed;
+		}else{
+			var processed = [];
+			for( var record in records ) {
+				processed.append( _processFields( record, fieldSettings ) );
+			}
+			$announceInterception( "postDataApiSelectData#namespace#", { selectDataArgs=args, entity=arguments.entity, data=processed } );
+			queryCache.set( "dataApi_#cacheKey#", processed);
+		}
 
 		return processed;
 	}

--- a/services/DataApiService.cfc
+++ b/services/DataApiService.cfc
@@ -285,11 +285,12 @@ component {
 		var useCache =		event.getValue( name="#objectName#_useCache", default =false, private=true );
 		var cachedProcessed=		queryCache.get( "dataApi_#cacheKey#" );
 
-		if ( useCache && !IsNull( local.cachedProcessed ) ) {
-			useCache = true
+		var existsCache =		false;
+		if ( !IsNull( local.cachedProcessed ) ) {
+			existsCache = true
 		}
 
-		var getFromCache = useCache && event.getValue( name="getFromCache", default =false, private=true );
+		var getFromCache = useCache && existsCache && event.getValue( name="getFromCache", default =false, private=true );
 
 		if(getFromCache){
 			var processed =	local.cachedProcessed;


### PR DESCRIPTION
We experience slow request in the processed data.

The difference is hudge between the jdbc time spent and the total time spent of the request and this time come from the 2 loop which is done in the processed data for api.

To prevent this time I add a check which check if the data come from the querycache or from the query database.

If the data come from the query database, the processed is done in the old way and it update a cache key with this info
If the data come from the query cache, I also get the processed data from the cahe, adding more speed to the request.

I hope this help and can be add soon to the extension. If is there anything I can do, let me know
