### PR TITLE
DATAAPI-25 Updated to use the same validation data for updating record

### DIFF
--- a/handlers/rest-apis/data/v1/SingleRecord.cfc
+++ b/handlers/rest-apis/data/v1/SingleRecord.cfc
@@ -74,7 +74,7 @@ component {
 		var updated = dataApiService.updateSingleRecord(
 			  entity   = entity
 			, recordId = recordId
-			, data     = body
+			, data     = validationData
 		);
 
 		if ( updated ) {


### PR DESCRIPTION
So that the same validation data that potentially manipulated on interception point 'preValidateUpsertData' or 'postValidateUpsertData' will be passed through to the update record.