### PR TITLE
DATAAPI-33 allow default configuration for apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ settings.rest.apis[ "/myGroovyApi/v1" ] = {
 	, description      = "REST API to expose data with an alternate structure"
 	, dataApiNamespace = "myGroovyApi"
 	, dataApiQueueEnabled = true
+	, dataApiDefaults     = { allowIdInsert=true, verbs="GET" }
 	, dataApiQueues       = {
 		default = { pageSize=100, atomicChanges=true }
 	  }

--- a/config/Config.cfc
+++ b/config/Config.cfc
@@ -27,6 +27,7 @@ component {
 			, description  = "Generic Preside REST API for external systems to interact with Preside data"
 			, configHandler = "dataApiManager"
 			, dataApiQueues = { default={ pageSize=1, name="", atomicChanges=false } }
+			, dataApiDefaults = { allowIdInsert=false }
 		};
 		settings.rest.apis[ "/data/v1/docs" ] = {
 			  description     = "Documentation for REST APIs (no authentication required)"

--- a/interceptors/DataApiInterceptors.cfc
+++ b/interceptors/DataApiInterceptors.cfc
@@ -21,6 +21,7 @@ component extends="coldbox.system.Interceptor" {
 		var dataApiNamespace   = "";
 		var dataApiDocs        = false;
 		var dataApiQueues      = {};
+		var dataApiDefaults    = {};
 		var base               = [];
 
 		for( var apiRoute in apiSettings ) {
@@ -29,6 +30,7 @@ component extends="coldbox.system.Interceptor" {
 				dataApiDocs   = isTrue( apiSettings[ apiRoute ].dataApiDocs ?: "" );
 				dataApiQueueEnabled = isTrue( apiSettings[ apiRoute ].dataApiQueueEnabled ?: !dataApiDocs );
 				dataApiQueues = apiSettings[ apiRoute ].dataApiQueues ?: {};
+				dataApiDefaults = apiSettings[ apiRoute ].dataApiDefaults ?: {};
 
 				dataApiConfigurationService.addDataApiRoute(
 					  dataApiRoute        = apiRoute
@@ -36,6 +38,7 @@ component extends="coldbox.system.Interceptor" {
 					, dataApiDocs         = dataApiDocs
 					, dataApiQueueEnabled = dataApiQueueEnabled
 					, dataApiQueues       = dataApiQueues
+					, dataApiDefaults     = dataApiDefaults
 				);
 
 				base = duplicate( dataApiDocs ? apis[ "/data/v1/docs" ] : apis[ "/data/v1" ] );
@@ -52,7 +55,8 @@ component extends="coldbox.system.Interceptor" {
 			, dataApiNamespace    = ""
 			, dataApiDocs         = false
 			, dataApiQueueEnabled = IsTrue( apiSettings[ "/data/v1" ].dataApiQueueEnabled ?: true )
-			, dataApiQueues       = apiSettings[ "/data/v1" ].dataApiQueues ?: {}
+			, dataApiQueues       = apiSettings[ "/data/v1" ].dataApiQueues   ?: {}
+			, dataApiDefaults     = apiSettings[ "/data/v1" ].dataApiDefaults ?: {}
 		);
 		dataApiConfigurationService.addDataApiRoute(
 			  dataApiRoute        = "/data/v1/docs"

--- a/services/DataApiConfigurationService.cfc
+++ b/services/DataApiConfigurationService.cfc
@@ -229,12 +229,12 @@ component {
 				if ( _isTrue( isEnabled ) ) {
 					var namespace           = _getNamespaceWithSeparator( args.namespace );
 					var entityName          = getObjectEntity( objectName, args.namespace );
-					var supportedVerbs      = poService.getObjectAttribute( objectName, "dataApiVerbs#namespace#", "" );
+					var supportedVerbs      = poService.getObjectAttribute( objectName, "dataApiVerbs#namespace#", getDefaultConfigForApiNamespace( "verbs", namespace ) );
 					var selectFields        = poService.getObjectAttribute( objectName, "dataApiFields#namespace#", "" );
 					var upsertFields        = poService.getObjectAttribute( objectName, "dataApiUpsertFields#namespace#", "" );
 					var excludeFields       = _getExcludedFields( objectName, namespace );
 					var upsertExcludeFields = _getExcludedFields( objectName, namespace, "upsert" );
-					var allowIdInsert       = poService.getObjectAttribute( objectName, "dataApiAllowIdInsert#namespace#", "" );
+					var allowIdInsert       = poService.getObjectAttribute( objectName, "dataApiAllowIdInsert#namespace#", getDefaultConfigForApiNamespace( "allowIdInsert", namespace ) );
 					var allowQueue          = poService.getObjectAttribute( objectName, "dataApiQueueEnabled#namespace#", true );
 					var queueName           = poService.getObjectAttribute( objectName, "dataApiQueue#namespace#", "default" );
 					var category            = poService.getObjectAttribute( objectName, "dataApiCategory#namespace#", "" );
@@ -382,6 +382,7 @@ component {
 		, required boolean dataApiDocs
 		, required boolean dataApiQueueEnabled
 		, required struct  dataApiQueues
+		,          struct  dataApiDefaults = {}
 	) {
 		variables._dataApiRoutes = variables._dataApiRoutes ?: {};
 		variables._dataApiRoutes[ arguments.dataApiRoute ] = {
@@ -389,6 +390,7 @@ component {
 			, dataApiDocs         = arguments.dataApiDocs
 			, dataApiQueueEnabled = arguments.dataApiQueueEnabled
 			, dataApiQueues       = arguments.dataApiQueues
+			, dataApiDefaults     = arguments.dataApiDefaults
 		};
 		_addNamespace( arguments.dataApiNamespace );
 	}
@@ -595,6 +597,12 @@ component {
 			, pageSize      = 1
 			, atomicChanges = false
 		};
+	}
+
+	public function getDefaultConfigForApiNamespace( required string key, string namespace=_getDataApiNamespace(), any defaultValue="" ) {
+		var route = getRouteForNamespace( arguments.namespace );
+
+		return route.dataApiDefaults[ arguments.key ] ?: arguments.defaultValue;
 	}
 
 // PRIVATE HELPERS


### PR DESCRIPTION
DATAAPI-32 caused a problem with fixing a bug that was being accidentally used.
ID inserts in POST requests were being accepted when they should not have been.
As a hasty fix, allow systems to set a global API-wide default behaviour for
allowIdInsert. i.e.

```
settings.rest.apis[ "/myapi" ] ={
// ...
   , dataApiDefaults = { allowIdInsert=true }
}
```