### PR TITLE
DATAAPI-37: support custom endpoints

### DIFF
--- a/interceptors/DataApiInterceptors.cfc
+++ b/interceptors/DataApiInterceptors.cfc
@@ -95,7 +95,7 @@ component extends="coldbox.system.Interceptor" {
 		if ( !IsSimpleValue( restRequest ) ) {
 			var api      = restRequest.getApi();
 			var resource = restRequest.getResource();
-			var regex    = "^data\.v1\.(WholeEntity|SingleRecord|Queue)";
+			var regex    = "^data\.v1\.(WholeEntity|SingleRecord|Queue|Docs)";
 
 			if ( api == "/data/v1" && reFindNoCase( regex, resource.handler ?: "" ) && resource.count() ) {
 				dataApiService.onRestRequest( restRequest, restResponse );

--- a/interceptors/DataApiInterceptors.cfc
+++ b/interceptors/DataApiInterceptors.cfc
@@ -95,15 +95,16 @@ component extends="coldbox.system.Interceptor" {
 		if ( !IsSimpleValue( restRequest ) ) {
 			var api      = restRequest.getApi();
 			var resource = restRequest.getResource();
+			var regex    = "^data\.v1\.(WholeEntity|SingleRecord|Queue)";
 
-			if ( api == "/data/v1" && resource.count() ) {
+			if ( api == "/data/v1" && reFindNoCase( regex, resource.handler ?: "" ) && resource.count() ) {
 				dataApiService.onRestRequest( restRequest, restResponse );
 				return;
 			}
 
 			var dataApiRoutes = dataApiConfigurationService.getDataApiRoutes();
 			for( var apiRoute in dataApiRoutes ) {
-				if ( api == apiRoute && reFindNoCase( "^data\.v1", resource.handler ?: "" ) ) {
+				if ( api == apiRoute && reFindNoCase( regex, resource.handler ?: "" ) ) {
 					event.setValue( "dataApiRoute"    , apiRoute );
 					event.setValue( "dataApiHandler"  , apiRoute.changeDelims( ".", "/" ) );
 					event.setValue( "dataApiNamespace", dataApiRoutes[ apiRoute ].dataApiNamespace );


### PR DESCRIPTION
Currently custom endpoints that are mixed into a data api only work on namespaced APIs, not on the default one (/data/v1). This is solved when explicitly checking for the full api handlers on rest request.

Examples:
/data/v1/entity/contact request will resolve to the handler data.v1.WholeEntity
/mycustomapi/v1/entity/contact request will also resolve to the handler data.v1.WholeEntity
/mycustomapi/v1/test/ will have a handler detected as mycustomapi.v1.test, therefore not being picked up by the Data API Service

But
/data/v1/test/ will have a handler detected as data.v1.test, being picked up by DataApiService and therefore leads to a 404