### PR TITLE
DATAAPI-46: skip queue flag updates

### DIFF
--- a/interceptors/DataApiInterceptors.cfc
+++ b/interceptors/DataApiInterceptors.cfc
@@ -118,7 +118,7 @@ component extends="coldbox.system.Interceptor" {
 	}
 
 	public void function preDeleteObjectData( event, interceptData ) {
-		if ( !_applicationLoaded ) return;
+		if ( _skipQueue( interceptData ) ) return;
 
 		if( isEmptyString( interceptData.id ?: "" ) ){
 			interceptData.deletedIds = dataApiQueueService.getDeletedRecordIds( argumentCollection = interceptData );
@@ -142,20 +142,13 @@ component extends="coldbox.system.Interceptor" {
 	}
 
 	public void function postDeleteObjectData( event, interceptData ) {
-		if ( !_applicationLoaded ) return;
-
-		var skipDataApiQueue = IsBoolean( interceptData.skipDataApiQueue ?: "" ) && interceptData.skipDataApiQueue;
-		var skipSyncQueue    = IsBoolean( interceptData.skipSyncQueue    ?: "" ) && interceptData.skipSyncQueue;
-
-		skipDataApiQueue = skipDataApiQueue || ( skipSyncQueue && dataApiConfigurationService.skipApiQueueWhenSkipSyncQueue( interceptData.objectName ) );
-
-		if( skipDataApiQueue ) return;
+		if ( _skipQueue( interceptData ) ) return;
 
 		dataApiQueueService.queueDelete( argumentCollection=interceptData );
 	}
 
 	public void function preUpdateObjectData( event, interceptData ) {
-		if ( !_applicationLoaded ) return;
+		if ( _skipQueue( interceptData ) ) return;
 
 		if ( dataApiQueueService.queueRequired( argumentCollection=interceptData ) ) {
 			interceptData.calculateChangedData = true;
@@ -163,28 +156,27 @@ component extends="coldbox.system.Interceptor" {
 	}
 
 	public void function postUpdateObjectData( event, interceptData ) {
-		if ( !_applicationLoaded ) return;
-
-		var skipDataApiQueue = IsBoolean( interceptData.skipDataApiQueue ?: "" ) && interceptData.skipDataApiQueue;
-		var skipSyncQueue    = IsBoolean( interceptData.skipSyncQueue    ?: "" ) && interceptData.skipSyncQueue;
-
-		skipDataApiQueue = skipDataApiQueue || ( skipSyncQueue && dataApiConfigurationService.skipApiQueueWhenSkipSyncQueue( interceptData.objectName ) );
-
-		if( skipDataApiQueue ) return;
+		if ( _skipQueue( interceptData ) ) return;
 
 		dataApiQueueService.queueUpdate( argumentCollection=interceptData );
 	}
 
 	public void function postInsertObjectData( event, interceptData ) {
-		if ( !_applicationLoaded ) return;
-
-		var skipDataApiQueue = IsBoolean( interceptData.skipDataApiQueue ?: "" ) && interceptData.skipDataApiQueue;
-		var skipSyncQueue    = IsBoolean( interceptData.skipSyncQueue    ?: "" ) && interceptData.skipSyncQueue;
-
-		skipDataApiQueue = skipDataApiQueue || ( skipSyncQueue && dataApiConfigurationService.skipApiQueueWhenSkipSyncQueue( interceptData.objectName ) );
-
-		if( skipDataApiQueue ) return;
+		if ( _skipQueue( interceptData ) ) return;
 
 		dataApiQueueService.queueInsert( argumentCollection=interceptData );
+	}
+
+	private boolean function _skipQueue( interceptData ) {
+
+		if ( !_applicationLoaded ) {
+			return true;
+		}
+
+		if ( IsTrue( interceptData.skipDataApiQueue ?: "" ) ) {
+			return true;
+		}
+
+		return IsTrue( interceptData.skipSyncQueue ?: "" ) && dataApiConfigurationService.skipApiQueueWhenSkipSyncQueue( interceptData.objectName );
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the conditions under which insert/update/delete operations are enqueued, which can alter downstream sync/queue behavior if the flags are set or interpreted differently.
> 
> **Overview**
> Refactors `DataApiInterceptors.cfc` to centralize all “should we queue?” checks into a new `_skipQueue(interceptData)` helper, replacing duplicated per-handler logic.
> 
> This makes `skipDataApiQueue` and the `skipSyncQueue`→API-queue bypass behavior consistent across `postInsertObjectData`, `postUpdateObjectData`, and `postDeleteObjectData`, while still short-circuiting when the application is not yet loaded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f792c6c88114b8cd6e1931c3b35b71f51532b2da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->