### PR TITLE
Add composite index api_queue_poll for data_api_queue

### DIFF
--- a/preside-objects/data_api_queue.cfc
+++ b/preside-objects/data_api_queue.cfc
@@ -10,16 +10,16 @@
  */
 component {
 	property name="object_name"     type="string"  dbtype="varchar" maxlength=100 required=true  indexes="object_name" renderer="DataApiQueueObjectName";
-	property name="namespace"       type="string"  dbtype="varchar" maxlength=50  required=false indexes="namespace";
-	property name="queue_name"      type="string"  dbtype="varchar" maxlength=50  required=false indexes="queuename";
+	property name="namespace"       type="string"  dbtype="varchar" maxlength=50  required=false indexes="namespace,api_queue_poll|3";
+	property name="queue_name"      type="string"  dbtype="varchar" maxlength=50  required=false indexes="queuename,api_queue_poll|2";
 	property name="record_id"       type="string"  dbtype="varchar" maxlength=100 required=true  indexes="record_id";
 	property name="operation"       type="string"  dbtype="varchar" maxlength=10  required=true  indexes="operation"   enum="dataApiQueueOperation";
-	property name="order_number"    type="numeric" dbtype="int"                   required=true  indexes="ordernumber" generate="insert" generator="method:getNextOrderNumber";
+	property name="order_number"    type="numeric" dbtype="int"                   required=true  indexes="ordernumber,api_queue_poll|4" generate="insert" generator="method:getNextOrderNumber";
 	property name="is_checked_out"  type="boolean" dbtype="boolean"               required=false indexes="checkedout" default=false;
 	property name="check_out_date"  type="date"    dbtype="datetime"              required=false indexes="checkedoutdate";
 	property name="data"            type="string"  dbtype="longtext"              required=false;
 
-	property name="subscriber" relatedto="rest_user" relationship="many-to-one" required=true;
+	property name="subscriber" relatedto="rest_user" relationship="many-to-one" required=true indexes="api_queue_poll|1";
 
 	public numeric function getNextOrderNumber() {
 		var record = this.selectData( selectFields = [ "Max( order_number ) as order_number" ] );


### PR DESCRIPTION
Reduce timeouts on API when queue gets large.
New composite index (subscriber, queue_name, namespace, order_number) aligns with DataApiQueueService.getNextQueuedItems and getQueueCount.
(related to DATAAPI-47) 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema/index-only change with minimal behavior impact; primary risk is migration/index creation time and any unintended query-plan changes under load.
> 
> **Overview**
> Improves performance of polling large `data_api_queue` tables by adding a new composite index `api_queue_poll` across `subscriber`, `queue_name`, `namespace`, and `order_number`.
> 
> This is implemented by updating the `indexes` metadata on the relevant properties in `preside-objects/data_api_queue.cfc` to define the composite index ordering while keeping existing single-column indexes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138691df7a2426834cdfb50f719bbed1b9c46c3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->