### PR TITLE
DATAAPI-49 Pagination options for performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Additional _optional_ annotation options at the _object_ level are:
 * `dataApiQueue`: Specific queue name for this object
 * `dataApiQueueDeleteDetail`: Whether or not the deleted record detail is available in the change queue data for this object
 * `dataApiSortOrder`: Sort order for paginated results. Default is date last modified ascending.
+* `dataApiPaginationMode`: Pagination strategy for GET list requests. One of `full` (default), `offset` or `cursor`. See [Pagination](##pagination), below.
 * `dataApiSavedFilters`: Comma-separated list of saved filters to apply to all requests to this object (e.g. only return active records)
 * `dataApiIgnoreDefaultFilters`: Comma-separated list of ignore default filters to apply to all requests to this object
 * `dataApiVerbs`: Supported REST HTTP Verbs. If not supplied, all verbs and operations are supported (i.e. GET, POST, PUT and DELETE)
@@ -69,6 +70,34 @@ Object properties support the following _optional_ annotations:
 * `dataApiEnabled`: Whether or not this property should be included in the API
 * `dataApiUpsertEnabled`: Whether or not this property should be included in the POST/PUT operations.
 * `dataApiRenderEmptyValues`: Whether to force always calling a custom render when the value being processed is empty or null
+
+## Pagination
+
+GET list requests (`GET /entity/{entity}/`) support three pagination modes, configured per object with the `dataApiPaginationMode` annotation (or per API namespace via the `paginationMode` default). The default is `full` so existing integrations are unaffected.
+
+* `full` (default): page based (`page` + `pageSize`). Returns the `X-Total-Records` and `X-Total-Pages` response headers as well as `Link` (`next`/`prev`). The total record count requires a `COUNT` query, which can be slow on very large tables.
+* `offset`: page based (`page` + `pageSize`), but without the total record count. The `X-Total-*` headers are omitted; `Link` (`next`/`prev`) is still returned (the next page is detected by over-fetching a single extra row). Use this when you want page based navigation without paying for the count.
+* `cursor`: keyset pagination. The `page` parameter is ignored; instead, pass the opaque `cursor` returned in the `Link` header of the previous response. This is the most performant option for very large tables as it never counts and never uses a growing `OFFSET`.
+
+Example, enabling cursor pagination on an object:
+
+```
+/**
+ * @dataApiEnabled        true
+ * @dataApiPaginationMode cursor
+ *
+ */
+component {
+	// ...
+}
+```
+
+### Notes and limitations of cursor pagination
+
+* Navigation is **forward only** (`Link: rel="next"`). There is no `prev` link.
+* The cursor is keyset based on the object's `dataApiSortOrder` (default: date last modified) plus the unique `id` as a tie-breaker, so ordering is always deterministic.
+* The primary sort column should be **non-null** and have **second (or coarser) precision** for fully reliable results. The default `datemodified`/`datecreated` fields satisfy this. A custom `dataApiSortOrder` pointing at a nullable or sub-second column may skip or duplicate rows at page boundaries.
+* The cursor is opaque and stateless. If a row's sort value changes between requests, the client simply continues from the encoded position (acceptable for sync style consumers).
 
 ## Custom renderers
 

--- a/config/Config.cfc
+++ b/config/Config.cfc
@@ -33,6 +33,7 @@ component {
 				, skipValidationOnUpdate = false
 				, responseTypeOnInsert   = "record" // "empty", "idonly" or "record" (default)
 				, responseTypeOnUpdate   = "record" // "empty", "idonly" or "record" (default)
+				, paginationMode         = "full"   // "full" (count + totals), "offset" (page based, no count) or "cursor" (keyset)
 			}
 		};
 		settings.rest.apis[ "/data/v1/docs" ] = {
@@ -43,6 +44,7 @@ component {
 
 	private void function _setupEnums( required struct settings ) {
 		settings.enum.dataApiQueueOperation = [ "insert", "update", "delete" ];
+		settings.enum.dataApiPaginationMode = [ "full", "offset", "cursor" ];
 	}
 
 	private void function _setupInterceptors( required struct conf ) {

--- a/handlers/rest-apis/data/v1/WholeEntity.cfc
+++ b/handlers/rest-apis/data/v1/WholeEntity.cfc
@@ -4,22 +4,37 @@
  */
 component {
 
-	property name="dataApiService" inject="dataApiService";
+	property name="dataApiService"              inject="dataApiService";
+	property name="dataApiConfigurationService" inject="dataApiConfigurationService";
 
 	private void function get(
 		  required string  entity
 		,          numeric page     = 1
 		,          numeric pageSize = 100
 		,          string  fields   = ""
+		,          string  cursor   = ""
 	) {
 		var filters  = {};
 		var filterQs = "";
+		var handler  = event.getValue( name="dataApiHandler", defaultValue="data.v1" );
 
 		for( var paramName in rc ) {
 			if ( paramName.reFindNoCase( "^filter\." ) ) {
 				filters[ paramName.reReplaceNoCase( "^filter\.", "" ) ] = rc[ paramName ];
 			}
 		}
+
+		if ( !isEmpty( filters ) ) {
+			for ( var f in filters ) {
+				filterQs &= "&filter.#f#=#filters[f]#";
+			}
+		}
+
+		if ( dataApiConfigurationService.entityUsesCursorPagination( arguments.entity ) ) {
+			_getCursorPage( entity=arguments.entity, pageSize=arguments.pageSize, fields=arguments.fields, cursor=arguments.cursor, filters=filters, filterQs=filterQs, handler=handler );
+			return;
+		}
+
 		var result = dataApiService.getPaginatedRecords(
 			  entity   = arguments.entity
 			, page     = arguments.page
@@ -29,18 +44,16 @@ component {
 		);
 
 		restResponse.setData( result.records );
-		restResponse.setHeader( "X-Total-Records", result.totalCount );
-		restResponse.setHeader( "X-Total-Pages", result.totalPages );
+
+		if ( StructKeyExists( result, "totalCount" ) ) {
+			restResponse.setHeader( "X-Total-Records", result.totalCount );
+		}
+		if ( StructKeyExists( result, "totalPages" ) ) {
+			restResponse.setHeader( "X-Total-Pages", result.totalPages );
+		}
 
 		var linkHeader      = "";
 		var linkHeaderDelim = "";
-		var handler         = event.getValue( name="dataApiHandler"  , defaultValue="data.v1" );
-
-		if ( !isEmpty( filters ) ) {
-			for ( var f in filters ) {
-				filterQs &= "&filter.#f#=#filters[f]#";
-			}
-		}
 
 		if ( result.nextPage ) {
 			var nextLink = event.buildLink( linkto="api.#handler#.entity.#arguments.entity#", queryString="pageSize=#arguments.pageSize#&page=#result.nextPage#" );
@@ -62,6 +75,46 @@ component {
 
 		if ( Len( linkHeader ) ) {
 			restResponse.setHeader( "Link", linkHeader );
+		}
+	}
+
+	private void function _getCursorPage(
+		  required string  entity
+		, required numeric pageSize
+		, required string  fields
+		, required string  cursor
+		, required struct  filters
+		, required string  filterQs
+		, required string  handler
+	) {
+		var result = "";
+
+		try {
+			result = dataApiService.getCursorRecords(
+				  entity   = arguments.entity
+				, pageSize = arguments.pageSize
+				, fields   = ListToArray( arguments.fields )
+				, cursor   = arguments.cursor
+				, filters  = arguments.filters
+			);
+		} catch( "dataApiCursor.invalid" e ) {
+			restResponse.setError(
+				  errorCode = 400
+				, title     = "Bad request"
+				, message   = e.message
+			);
+			return;
+		}
+
+		restResponse.setData( result.records );
+
+		if ( Len( result.nextCursor ) ) {
+			var nextLink = event.buildLink( linkto="api.#arguments.handler#.entity.#arguments.entity#", queryString="pageSize=#arguments.pageSize#&cursor=#URLEncodedFormat( result.nextCursor )#" );
+			if ( !isEmptyString( arguments.filterQs ) ) {
+				nextLink &= "#arguments.filterQs#";
+			}
+
+			restResponse.setHeader( "Link", "<#nextLink#>; rel=""next""" );
 		}
 	}
 

--- a/handlers/rest-apis/data/v1/WholeEntity.cfc
+++ b/handlers/rest-apis/data/v1/WholeEntity.cfc
@@ -31,7 +31,16 @@ component {
 		}
 
 		if ( dataApiConfigurationService.entityUsesCursorPagination( arguments.entity ) ) {
-			_getCursorPage( entity=arguments.entity, pageSize=arguments.pageSize, fields=arguments.fields, cursor=arguments.cursor, filters=filters, filterQs=filterQs, handler=handler );
+			_getCursorPage(
+				  argumentCollection = arguments
+				, entity             = arguments.entity
+				, pageSize           = arguments.pageSize
+				, fields             = arguments.fields
+				, cursor             = arguments.cursor
+				, filters            = filters
+				, filterQs           = filterQs
+				, handler            = handler
+			);
 			return;
 		}
 
@@ -86,6 +95,7 @@ component {
 		, required struct  filters
 		, required string  filterQs
 		, required string  handler
+		, required any     restResponse
 	) {
 		var result = "";
 

--- a/i18n/dataapi.properties
+++ b/i18n/dataapi.properties
@@ -3,13 +3,22 @@ api.description=API allowing access to data stored in the Preside system.
 api.version=1.0.0
 
 trait.pagination.title=Pagination
-trait.pagination.description=Pagination is performed with two query parameters, `page` and `pageSize`. If omitted, these will default to `1` and `100` respectively.\n\
+trait.pagination.intro=List endpoints (`GET /entity/{entity}/`) are paginated. The pagination strategy can vary per entity; the strategies in use by this API are described below.
+trait.pagination.full.description=**Full (page based, with total count)**\n\
+\n\
+Pagination is performed with two query parameters, `page` and `pageSize`. If omitted, these will default to `1` and `100` respectively.\n\
 \n\
 When returning a successful response, the API will set three pagination related headers:\n\
 \n\
 1. `X-Total-Records`: The total number of records in the recordset\n\
 2. `X-Total-Pages`: The total number of paginated pages in the recordset (based on the `pageSize`)\n\
 3. `Link`: Links to _next_ and _previous_ URLs to use when fetching the previous or next page of results. In the form: `<{nexthref}>; rel="next", <{prevhref}>; rel="prev"`
+trait.pagination.offset.description=**Offset (page based, no total count)**\n\
+\n\
+Pagination is performed with the `page` and `pageSize` query parameters (defaulting to `1` and `100`). No total record count is calculated, so the `X-Total-Records` and `X-Total-Pages` headers are _not_ returned. A `Link` header is still provided with _next_ and _previous_ URLs where applicable, in the form: `<{nexthref}>; rel="next", <{prevhref}>; rel="prev"`.
+trait.pagination.cursor.description=**Cursor (keyset)**\n\
+\n\
+Pagination is performed with a `pageSize` query parameter and an opaque `cursor` query parameter. To fetch the first page, omit the `cursor`. Each successful response includes a `Link` header containing the URL for the _next_ page when more records are available, in the form: `<{nexthref}>; rel="next"`. Follow this link to page through the results. Navigation is forward only and no total record count is returned.
 
 trait.errorhandling.title=Error handling
 trait.errorhandling.description=When an operation is successful, a `20x` status will be returned. Non `20x` status codes will be returned for controlled errors such as authentication and badly formatted input data. These errors are documented with the expected return bodies in the individual method documentation, below.\n\

--- a/i18n/dataapi.properties
+++ b/i18n/dataapi.properties
@@ -71,6 +71,7 @@ operation.queue.batch.delete.post.body.description=Array of queue item IDs (UUID
 
 operation.get.description=Used to fetch **{1}** records from the system.
 operation.get.params.page=For pagination; the page number to fetch. Default is 1.
+operation.get.params.cursor=For cursor (keyset) pagination; the opaque cursor returned in the `Link` header of the previous response. Omit to fetch the first page.
 operation.get.params.pageSize=For pagination; the number of records per page. Default is 100.
 operation.get.params.fields=Comma separated list of fields to fetch per record. Default is all fields. Possible values: [`{2}`].
 operation.get.200.description=Array of **{1}** records

--- a/i18n/enum/dataApiPaginationMode.properties
+++ b/i18n/enum/dataApiPaginationMode.properties
@@ -1,0 +1,6 @@
+full.label=Full (page based, with total record count)
+full.description=Page based pagination returning total record count and total page headers. Accurate but can be slow on very large tables.
+offset.label=Offset (page based, no total count)
+offset.description=Page based pagination without a total record count. Next/previous links are still provided.
+cursor.label=Cursor (keyset)
+cursor.description=Keyset pagination using an opaque cursor. Most performant for very large tables, but navigation is forward only via the cursor.

--- a/services/DataApiConfigurationService.cfc
+++ b/services/DataApiConfigurationService.cfc
@@ -11,6 +11,13 @@ component {
 	};
 	DEFAULT_RESPONSE_TYPE = VALID_RESPONSE_TYPES.RECORD;
 
+	VALID_PAGINATION_MODES = {
+		  FULL   = "full"
+		, OFFSET = "offset"
+		, CURSOR = "cursor"
+	};
+	DEFAULT_PAGINATION_MODE = VALID_PAGINATION_MODES.FULL;
+
 // CONSTRUCTOR
 	/**
 	 * @presideFieldRuleGenerator.inject presideFieldRuleGenerator
@@ -53,6 +60,22 @@ component {
 
 	public boolean function entitySkipValidationOnUpdate( required string entity ) {
 		return _entityIsBooleanConfigOptionTrue( arguments.entity, "skipValidationOnUpdate" );
+	}
+
+	public string function getEntityPaginationMode( required string entity ) {
+		return _entityConfigOption( arguments.entity, "paginationMode", DEFAULT_PAGINATION_MODE );
+	}
+
+	public boolean function entityUsesCursorPagination( required string entity ) {
+		return getEntityPaginationMode( arguments.entity ) == VALID_PAGINATION_MODES.CURSOR;
+	}
+
+	public boolean function entityCountsTotalRecords( required string entity ) {
+		return getEntityPaginationMode( arguments.entity ) == VALID_PAGINATION_MODES.FULL;
+	}
+
+	public boolean function isValidPaginationMode( required string mode ) {
+		return ArrayFindNoCase( [ VALID_PAGINATION_MODES.FULL, VALID_PAGINATION_MODES.OFFSET, VALID_PAGINATION_MODES.CURSOR ], arguments.mode ) > 0;
 	}
 
 	public string function entityResponseTypeOnInsert( required string entity ) {
@@ -301,6 +324,7 @@ component {
 					var allowQueue             = poService.getObjectAttribute( objectName, "dataApiQueueEnabled#namespace#", true );
 					var queueName              = poService.getObjectAttribute( objectName, "dataApiQueue#namespace#", "default" );
 					var category               = poService.getObjectAttribute( objectName, "dataApiCategory#namespace#", "" );
+					var paginationMode         = poService.getObjectAttribute( objectName, "dataApiPaginationMode#namespace#", getDefaultConfigForApiNamespace( "paginationMode", namespace, DEFAULT_PAGINATION_MODE ) );
 
 					entities[ entityName ] = {
 						  objectName             = objectName
@@ -315,6 +339,7 @@ component {
 						, responseTypeOnUpdate   = isValidResponseType( responseTypeOnUpdate ) ? responseTypeOnUpdate : DEFAULT_RESPONSE_TYPE
 						, allowQueue             = _isTrue( allowQueue    )
 						, queueName              = queueName
+						, paginationMode         = isValidPaginationMode( paginationMode ) ? LCase( paginationMode ) : DEFAULT_PAGINATION_MODE
 					};
 
 					if ( !entities[ entityName ].selectFields.len() ) {

--- a/services/DataApiConfigurationService.cfc
+++ b/services/DataApiConfigurationService.cfc
@@ -75,7 +75,30 @@ component {
 	}
 
 	public boolean function isValidPaginationMode( required string mode ) {
-		return ArrayFindNoCase( [ VALID_PAGINATION_MODES.FULL, VALID_PAGINATION_MODES.OFFSET, VALID_PAGINATION_MODES.CURSOR ], arguments.mode ) > 0;
+		return ArrayFindNoCase( _getValidPaginationModes(), arguments.mode ) > 0;
+	}
+
+	public array function getPaginationModesInUse( string namespace=_getDataApiNamespace() ) {
+		var args     = arguments;
+		var cacheKey = "getPaginationModesInUse" & args.namespace;
+
+		return _simpleLocalCache( cacheKey, function(){
+			var entities = getEntities( args.namespace );
+			var inUse    = {};
+
+			for( var entityName in entities ) {
+				inUse[ entities[ entityName ].paginationMode ?: DEFAULT_PAGINATION_MODE ] = true;
+			}
+
+			var ordered = [];
+			for( var mode in _getValidPaginationModes() ) {
+				if ( inUse.keyExists( mode ) ) {
+					ArrayAppend( ordered, mode );
+				}
+			}
+
+			return ordered;
+		} );
 	}
 
 	public string function entityResponseTypeOnInsert( required string entity ) {
@@ -720,6 +743,10 @@ component {
 
 			return result;
 		} );
+	}
+
+	public array function _getValidPaginationModes() {
+		return [ VALID_PAGINATION_MODES.FULL, VALID_PAGINATION_MODES.OFFSET, VALID_PAGINATION_MODES.CURSOR ];
 	}
 
 	private any function _simpleLocalCache( required string cacheKey, required any generator ) {

--- a/services/DataApiService.cfc
+++ b/services/DataApiService.cfc
@@ -50,7 +50,8 @@ component {
 		, required array   fields
 		,          struct  filters = {}
 	) {
-		var args = {
+		var countTotalRecords = _getConfigService().entityCountsTotalRecords( arguments.entity );
+		var args              = {
 			  maxRows      = pageSize
 			, startRow     = ( ( arguments.page - 1 ) * arguments.pageSize ) + 1
 			, orderby      = "datemodified"
@@ -67,19 +68,66 @@ component {
 		_prepareFilters( arguments.entity, arguments.filters, args );
 
 		var result = {
-			records = _selectData( arguments.entity, args, arguments.fields )
+			  prevPage = arguments.page - 1
+			, nextPage = 0
 		};
 
-		args.recordCountOnly = true;
-		structDelete( args, "maxRows" );
+		if ( countTotalRecords ) {
+			result.records = _selectData( arguments.entity, args, arguments.fields );
 
-		result.totalCount = _selectData( arguments.entity, args, arguments.fields )
+			args.recordCountOnly = true;
+			structDelete( args, "maxRows" );
 
-		result.totalPages = Ceiling( result.totalCount / arguments.pageSize );
-		result.prevPage   = arguments.page -1;
-		result.nextPage   = arguments.page >= result.totalPages ? 0 : arguments.page+1;
+			result.totalCount = _selectData( arguments.entity, args, arguments.fields );
+			result.totalPages = Ceiling( result.totalCount / arguments.pageSize );
+			result.nextPage   = arguments.page >= result.totalPages ? 0 : arguments.page + 1;
+		} else {
+			var effectivePageSize = args.maxRows;
+
+			args.maxRows   = effectivePageSize + 1;
+			result.records = _selectData( arguments.entity, args, arguments.fields );
+
+			if ( ArrayLen( result.records ) > effectivePageSize ) {
+				ArrayDeleteAt( result.records, ArrayLen( result.records ) );
+				result.nextPage = arguments.page + 1;
+			}
+		}
 
 		return result;
+	}
+
+	public struct function getCursorRecords(
+		  required string  entity
+		, required numeric pageSize
+		, required array   fields
+		,          string  cursor  = ""
+		,          struct  filters = {}
+	) {
+		var configService = _getConfigService();
+		var objectName    = configService.getEntityObject( arguments.entity );
+		var idField       = $getPresideObjectService().getIdField( objectName );
+		var sort          = _resolveCursorSort( arguments.entity, idField );
+		var pageSize      = arguments.pageSize < 1 ? 100 : arguments.pageSize;
+
+		var args = {
+			  maxRows      = pageSize + 1
+			, filter       = {}
+			, extraFilters = []
+		};
+
+		_prepareFilters( arguments.entity, arguments.filters, args );
+
+		if ( Len( Trim( arguments.cursor ) ) ) {
+			_appendKeysetFilter( objectName, sort, _decodeCursor( arguments.cursor, sort ), args );
+		}
+
+		return _selectCursorPage(
+			  entity   = arguments.entity
+			, args     = args
+			, fields   = arguments.fields
+			, sort     = sort
+			, pageSize = pageSize
+		);
 	}
 
 	public any function getSingleRecord( required string entity, required string recordId, required array fields ) {
@@ -337,15 +385,23 @@ component {
 		var namespace     = _getInterceptorNamespace();
 		var fieldSettings = configService.getFieldSettings( arguments.entity );
 
-		args.selectFields            = _prepareSelectFields( arguments.entity, objectName, configService.getSelectFields( arguments.entity ), arguments.fields );
+		args.recordCountOnly = args.recordCountOnly ?: false;
+
+		if ( args.recordCountOnly ) {
+			args.selectFields = [ "1" ];
+			args.distinct     = false;
+			args.autoGroupBy  = false;
+		} else {
+			args.selectFields = _prepareSelectFields( arguments.entity, objectName, configService.getSelectFields( arguments.entity ), arguments.fields );
+			args.orderBy      = configService.getSelectSortOrder( arguments.entity );
+			args.distinct     = true;
+			args.autoGroupBy  = true;
+		}
+
 		args.fromVersionTable        = false;
-		args.orderBy                 = configService.getSelectSortOrder( arguments.entity );
 		args.savedFilters            = configService.getSavedFilters( arguments.entity );
 		args.ignoreDefaultFilters    = configService.getIgnoreDefaultFilters( arguments.entity );
 		args.allowDraftVersions      = false;
-		args.autoGroupBy             = true;
-		args.distinct                = true;
-		args.recordCountOnly         = args.recordCountOnly ?: false;
 
 		$announceInterception( "preDataApiSelectData#namespace#", { selectDataArgs=args, entity=arguments.entity } );
 
@@ -366,6 +422,138 @@ component {
 		$announceInterception( "postDataApiSelectData#namespace#", { selectDataArgs=args, entity=arguments.entity, data=processed } );
 
 		return processed;
+	}
+
+	private struct function _selectCursorPage(
+		  required string  entity
+		, required struct  args
+		, required array   fields
+		, required struct  sort
+		, required numeric pageSize
+	) {
+		var configService = _getConfigService();
+		var objectName    = configService.getEntityObject( arguments.entity );
+		var dao           = $getPresideObject( objectName );
+		var namespace     = _getInterceptorNamespace();
+		var fieldSettings = configService.getFieldSettings( arguments.entity );
+		var dbAdapter     = $getPresideObjectService().getDbAdapterForObject( objectName );
+		var args          = arguments.args;
+
+		args.selectFields         = _prepareSelectFields( arguments.entity, objectName, configService.getSelectFields( arguments.entity ), arguments.fields );
+		args.fromVersionTable     = false;
+		args.savedFilters         = configService.getSavedFilters( arguments.entity );
+		args.ignoreDefaultFilters = configService.getIgnoreDefaultFilters( arguments.entity );
+		args.allowDraftVersions   = false;
+		args.distinct             = true;
+		args.autoGroupBy          = true;
+		args.recordCountOnly      = false;
+		args.returnType           = "array";
+		args.orderBy              = "#arguments.sort.field# #arguments.sort.direction#, #arguments.sort.idField# #arguments.sort.direction#";
+
+		ArrayAppend( args.selectFields, "#dbAdapter.escapeEntity( '#objectName#.#arguments.sort.field#' )# as __cursor_sort_value" );
+
+		$announceInterception( "preDataApiSelectData#namespace#", { selectDataArgs=args, entity=arguments.entity } );
+
+		if ( !ArrayLen( args.selectFields ) ) {
+			throw( "Invaid select field" );
+		}
+
+		var records    = dao.selectData( argumentCollection=args );
+		var hasNext    = ArrayLen( records ) > arguments.pageSize;
+		var processed  = [];
+		var nextCursor = "";
+
+		if ( hasNext ) {
+			ArrayDeleteAt( records, ArrayLen( records ) );
+		}
+
+		var lastIndex = ArrayLen( records );
+		for( var i=1; i<=lastIndex; i++ ) {
+			var record = records[ i ];
+
+			if ( hasNext && i == lastIndex ) {
+				nextCursor = _encodeCursor( arguments.sort, record[ "__cursor_sort_value" ] ?: "", record[ arguments.sort.idField ] ?: "" );
+			}
+
+			StructDelete( record, "__cursor_sort_value" );
+			processed.append( _processFields( record, fieldSettings ) );
+		}
+
+		$announceInterception( "postDataApiSelectData#namespace#", { selectDataArgs=args, entity=arguments.entity, data=processed } );
+
+		return { records=processed, nextCursor=nextCursor };
+	}
+
+	private struct function _resolveCursorSort( required string entity, required string idField ) {
+		var sortOrder = _getConfigService().getSelectSortOrder( arguments.entity );
+		var firstCol  = Trim( ListFirst( sortOrder, "," ) );
+		var parts     = ListToArray( firstCol, " " );
+		var field     = ArrayLen( parts ) >= 1 ? parts[ 1 ] : arguments.idField;
+		var direction = ArrayLen( parts ) >= 2 ? LCase( parts[ 2 ] ) : "asc";
+
+		if ( direction != "desc" ) {
+			direction = "asc";
+		}
+
+		return {
+			  field     = field
+			, direction = direction
+			, idField   = arguments.idField
+		};
+	}
+
+	private void function _appendKeysetFilter( required string objectName, required struct sort, required struct cursorData, required struct args ) {
+		var poService = $getPresideObjectService();
+		var dbAdapter = poService.getDbAdapterForObject( arguments.objectName );
+		var fieldType = poService.getObjectPropertyAttribute( arguments.objectName, arguments.sort.field, "dbtype" );
+		var escSort   = dbAdapter.escapeEntity( "#arguments.objectName#.#arguments.sort.field#" );
+		var escId     = dbAdapter.escapeEntity( "#arguments.objectName#.#arguments.sort.idField#" );
+		var op        = arguments.sort.direction == "desc" ? "<" : ">";
+		var sortType  = Len( Trim( fieldType ) ) ? dbAdapter.sqlDataTypeToCfSqlDatatype( fieldType ) : "cf_sql_varchar";
+
+		ArrayAppend( arguments.args.extraFilters, {
+			  filter       = "( #escSort# #op# :cursorSortA or ( #escSort# = :cursorSortB and #escId# #op# :cursorId ) )"
+			, filterParams = {
+				  cursorSortA = { type=sortType, value=arguments.cursorData.v  }
+				, cursorSortB = { type=sortType, value=arguments.cursorData.v  }
+				, cursorId    = { type="cf_sql_varchar", value=arguments.cursorData.id }
+			  }
+		} );
+	}
+
+	private string function _encodeCursor( required struct sort, required any sortValue, required string id ) {
+		var value = arguments.sortValue;
+
+		if ( IsDate( value ) ) {
+			value = DateTimeFormat( value, "yyyy-mm-dd HH:nn:ss" );
+		}
+
+		return ToBase64( SerializeJson( {
+			  f  = arguments.sort.field
+			, d  = arguments.sort.direction
+			, v  = value
+			, id = arguments.id
+		} ) );
+	}
+
+	private struct function _decodeCursor( required string cursor, required struct sort ) {
+		var payload = "";
+
+		try {
+			payload = DeserializeJson( ToString( ToBinary( arguments.cursor ) ) );
+		} catch( any e ) {
+			throw( type="dataApiCursor.invalid", message="The supplied pagination cursor could not be decoded." );
+		}
+
+		if ( !IsStruct( payload ) || !StructKeyExists( payload, "v" ) || !StructKeyExists( payload, "id" ) ) {
+			throw( type="dataApiCursor.invalid", message="The supplied pagination cursor is not valid." );
+		}
+
+		if ( ( payload.f ?: "" ) != arguments.sort.field || ( payload.d ?: "" ) != arguments.sort.direction ) {
+			throw( type="dataApiCursor.invalid", message="The supplied pagination cursor does not match the current sort order." );
+		}
+
+		return { v=payload.v, id=payload.id };
 	}
 
 	private struct function _processFields( required struct record, required struct fieldSettings ) {

--- a/services/DataApiService.cfc
+++ b/services/DataApiService.cfc
@@ -458,7 +458,7 @@ component {
 			throw( "Invaid select field" );
 		}
 
-		var records    = dao.selectData( argumentCollection=args );
+		var records    = Duplicate( dao.selectData( argumentCollection=args ) );
 		var hasNext    = ArrayLen( records ) > arguments.pageSize;
 		var processed  = [];
 		var nextCursor = "";

--- a/services/DataApiSpecService.cfc
+++ b/services/DataApiSpecService.cfc
@@ -94,7 +94,7 @@ component {
 	private void function _addTraits( required struct spec ) {
 		spec.tags.append({
 			  name         = _i18nNamespaced( "dataapi:trait.pagination.title" )
-			, description  = _i18nNamespaced( "dataapi:trait.pagination.description" )
+			, description  = _buildPaginationTraitDescription()
 			, "x-traitTag" = true
 		});
 		spec.tags.append({
@@ -102,6 +102,22 @@ component {
 			, description  = _i18nNamespaced( "dataapi:trait.errorhandling.description" )
 			, "x-traitTag" = true
 		});
+	}
+
+	private string function _buildPaginationTraitDescription() {
+		var namespace = $getRequestContext().getValue( name="dataApiNamespace", defaultValue="" );
+		var modes     = _getConfigService().getPaginationModesInUse( namespace );
+		var sections  = [ _i18nNamespaced( uri="dataapi:trait.pagination.intro", defaultValue="" ) ];
+
+		for( var mode in modes ) {
+			ArrayAppend( sections, _i18nNamespaced( uri="dataapi:trait.pagination.#mode#.description", defaultValue="" ) );
+		}
+
+		sections = sections.filter( function( section ){
+			return Len( Trim( arguments.section ) );
+		} );
+
+		return ArrayToList( sections, Chr( 10 ) & Chr( 10 ) );
 	}
 
 	private void function _addCommonHeaderSpecs( required struct spec ) {
@@ -342,7 +358,7 @@ component {
 				}
 
 				var getResponseHeaders = { "Link" = { "$ref"="##/components/headers/Link" } };
-				if ( !isCursorMode ) {
+				if ( configService.entityCountsTotalRecords( entityName ) ) {
 					getResponseHeaders[ "X-Total-Records" ] = { "$ref"="##/components/headers/XTotalRecords" };
 					getResponseHeaders[ "X-Total-Pages"   ] = { "$ref"="##/components/headers/XTotalPages" };
 				}

--- a/services/DataApiSpecService.cfc
+++ b/services/DataApiSpecService.cfc
@@ -696,10 +696,6 @@ component {
 		var propName      = configService.getPropertyNameFromFieldAlias( arguments.entity, arguments.field );
 		var dbtype        = $getPresideObjectService().getObjectPropertyAttribute( objectName, propName, "dbtype" );
 
-		if ( arguments.field == "datemodified" ) {
-			dump( dbtype );abort;
-		}
-
 		return ReFindNoCase( "^date", dbtype );
 	}
 

--- a/services/DataApiSpecService.cfc
+++ b/services/DataApiSpecService.cfc
@@ -286,13 +286,21 @@ component {
 
 			if ( configService.entityVerbIsSupported( entityName, "get" ) ) {
 				var fieldsFilterList = configService.getSelectFields( entityName, true ).toList( ", " );
-				var params = [ {
+				var isCursorMode     = configService.entityUsesCursorPagination( entityName );
+				var firstParam       = isCursorMode ? {
+					name        = "cursor"
+				  , in          = "query"
+				  , required    = false
+				  , description = _i18nNamespaced( uri="dataapi:operation.get.params.cursor", defaultValue="", data=[ entityTag ] )
+				  , schema      = { type="string" }
+				} : {
 					name        = "page"
 				  , in          = "query"
 				  , required    = false
 				  , description = _i18nNamespaced( uri="dataapi:operation.get.params.page", defaultValue="", data=[ entityTag ] )
 				  , schema      = { type="integer" }
-				},{
+				};
+				var params = [ firstParam, {
 					name        = "pageSize"
 				  , in          = "query"
 				  , required    = false
@@ -333,6 +341,12 @@ component {
 					}
 				}
 
+				var getResponseHeaders = { "Link" = { "$ref"="##/components/headers/Link" } };
+				if ( !isCursorMode ) {
+					getResponseHeaders[ "X-Total-Records" ] = { "$ref"="##/components/headers/XTotalRecords" };
+					getResponseHeaders[ "X-Total-Pages"   ] = { "$ref"="##/components/headers/XTotalPages" };
+				}
+
 				spec.paths[ "/entity/#entityName#/" ].get = {
 					  tags = [ entityTag ]
 					, summary = "GET /entity/#entityName#/"
@@ -341,11 +355,7 @@ component {
 					, responses = { "200" = {
 						  description = _i18nNamespaced( uri="dataapi:operation.#entityName#.get.200.description", defaultValue=_i18nNamespaced( uri="dataapi:operation.get.200.description", defaultValue="", data=[ entitySingular ] ) )
 						, content     = { "application/json" = { schema={ type="array", items={"$ref"="##/components/schemas/#entityName#" } } } }
-						, headers     = {
-							  "X-Total-Records" = { "$ref"="##/components/headers/XTotalRecords" }
-							, "X-Total-Pages"   = { "$ref"="##/components/headers/XTotalPages" }
-							, "Link"            = { "$ref"="##/components/headers/Link" }
-						  }
+						, headers     = getResponseHeaders
 					  } }
 				};
 
@@ -685,6 +695,10 @@ component {
 		var objectName    = configService.getEntityObject( arguments.entity );
 		var propName      = configService.getPropertyNameFromFieldAlias( arguments.entity, arguments.field );
 		var dbtype        = $getPresideObjectService().getObjectPropertyAttribute( objectName, propName, "dbtype" );
+
+		if ( arguments.field == "datemodified" ) {
+			dump( dbtype );abort;
+		}
 
 		return ReFindNoCase( "^date", dbtype );
 	}


### PR DESCRIPTION
The existing pagination works well enough for entities with few records. However, it is very problematic when entities hold a large data set.

Provide options for pagination that can help improve performance for large datasets.
