### PR TITLE
DATAAPI-51 dynamic pagination types

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Additional _optional_ annotation options at the _object_ level are:
 * `dataApiQueue`: Specific queue name for this object
 * `dataApiQueueDeleteDetail`: Whether or not the deleted record detail is available in the change queue data for this object
 * `dataApiSortOrder`: Sort order for paginated results. Default is date last modified ascending.
-* `dataApiPaginationMode`: Pagination strategy for GET list requests. One of `full` (default), `offset` or `cursor`. See [Pagination](##pagination), below.
+* `dataApiPaginationMode`: Default pagination strategy for GET list requests when the client does not supply a `paginationMode` query parameter. One of `full` (default), `offset` or `cursor`. See [Pagination](##pagination), below.
+* `dataApiAllowedPaginationModes`: Optional comma-separated list restricting which pagination modes clients may request for this object (e.g. `full,offset`). When omitted, all modes are allowed.
 * `dataApiSavedFilters`: Comma-separated list of saved filters to apply to all requests to this object (e.g. only return active records)
 * `dataApiIgnoreDefaultFilters`: Comma-separated list of ignore default filters to apply to all requests to this object
 * `dataApiVerbs`: Supported REST HTTP Verbs. If not supplied, all verbs and operations are supported (i.e. GET, POST, PUT and DELETE)
@@ -73,13 +74,15 @@ Object properties support the following _optional_ annotations:
 
 ## Pagination
 
-GET list requests (`GET /entity/{entity}/`) support three pagination modes, configured per object with the `dataApiPaginationMode` annotation (or per API namespace via the `paginationMode` default). The default is `full` so existing integrations are unaffected.
+GET list requests (`GET /entity/{entity}/`) support three pagination modes. Clients choose the mode per request with the `paginationMode` query parameter. When omitted, the default for the entity (via `dataApiPaginationMode`) or API namespace (via `paginationMode` in route defaults) is used; the system default is `full` so existing integrations are unaffected.
+
+Developers can restrict which modes clients may use with `allowedPaginationModes` in API route defaults and/or `dataApiAllowedPaginationModes` on individual objects.
 
 * `full` (default): page based (`page` + `pageSize`). Returns the `X-Total-Records` and `X-Total-Pages` response headers as well as `Link` (`next`/`prev`). The total record count requires a `COUNT` query, which can be slow on very large tables.
 * `offset`: page based (`page` + `pageSize`), but without the total record count. The `X-Total-*` headers are omitted; `Link` (`next`/`prev`) is still returned (the next page is detected by over-fetching a single extra row). Use this when you want page based navigation without paying for the count.
 * `cursor`: keyset pagination. The `page` parameter is ignored; instead, pass the opaque `cursor` returned in the `Link` header of the previous response. This is the most performant option for very large tables as it never counts and never uses a growing `OFFSET`.
 
-Example, enabling cursor pagination on an object:
+Example, setting cursor pagination as the default for an object:
 
 ```
 /**
@@ -90,6 +93,18 @@ Example, enabling cursor pagination on an object:
 component {
 	// ...
 }
+```
+
+Example, restricting an API namespace to offset and cursor pagination only:
+
+```
+settings.rest.apis[ "/data/v1" ] = {
+    // ...
+    dataApiDefaults = {
+        paginationMode         = "offset"
+      , allowedPaginationModes = [ "offset", "cursor" ]
+    }
+};
 ```
 
 ### Notes and limitations of cursor pagination

--- a/config/Config.cfc
+++ b/config/Config.cfc
@@ -34,6 +34,7 @@ component {
 				, responseTypeOnInsert   = "record" // "empty", "idonly" or "record" (default)
 				, responseTypeOnUpdate   = "record" // "empty", "idonly" or "record" (default)
 				, paginationMode         = "full"   // "full" (count + totals), "offset" (page based, no count) or "cursor" (keyset)
+				, allowedPaginationModes = []       // empty = all modes allowed; otherwise restrict to listed modes
 			}
 		};
 		settings.rest.apis[ "/data/v1/docs" ] = {

--- a/handlers/rest-apis/data/v1/WholeEntity.cfc
+++ b/handlers/rest-apis/data/v1/WholeEntity.cfc
@@ -9,14 +9,16 @@ component {
 
 	private void function get(
 		  required string  entity
-		,          numeric page     = 1
-		,          numeric pageSize = 100
-		,          string  fields   = ""
-		,          string  cursor   = ""
+		,          numeric page           = 1
+		,          numeric pageSize       = 100
+		,          string  fields         = ""
+		,          string  cursor         = ""
+		,          string  paginationMode = ""
 	) {
 		var filters  = {};
 		var filterQs = "";
 		var handler  = event.getValue( name="dataApiHandler", defaultValue="data.v1" );
+		var resolvedPaginationMode = "";
 
 		for( var paramName in rc ) {
 			if ( paramName.reFindNoCase( "^filter\." ) ) {
@@ -30,7 +32,21 @@ component {
 			}
 		}
 
-		if ( dataApiConfigurationService.entityUsesCursorPagination( arguments.entity ) ) {
+		try {
+			resolvedPaginationMode = dataApiConfigurationService.resolvePaginationMode(
+				  entity        = arguments.entity
+				, requestedMode = arguments.paginationMode
+			);
+		} catch( "dataApiPaginationMode.invalid dataApiPaginationMode.notAllowed" e ) {
+			restResponse.setError(
+				  errorCode = 400
+				, title     = "Bad request"
+				, message   = e.message
+			);
+			return;
+		}
+
+		if ( dataApiConfigurationService.paginationModeUsesCursor( resolvedPaginationMode ) ) {
 			_getCursorPage(
 				  argumentCollection = arguments
 				, entity             = arguments.entity
@@ -40,16 +56,18 @@ component {
 				, filters            = filters
 				, filterQs           = filterQs
 				, handler            = handler
+				, paginationMode     = resolvedPaginationMode
 			);
 			return;
 		}
 
 		var result = dataApiService.getPaginatedRecords(
-			  entity   = arguments.entity
-			, page     = arguments.page
-			, pageSize = arguments.pageSize
-			, fields   = ListToArray( arguments.fields )
-			, filters  = filters
+			  entity         = arguments.entity
+			, page           = arguments.page
+			, pageSize       = arguments.pageSize
+			, fields         = ListToArray( arguments.fields )
+			, filters        = filters
+			, paginationMode = resolvedPaginationMode
 		);
 
 		restResponse.setData( result.records );
@@ -63,9 +81,10 @@ component {
 
 		var linkHeader      = "";
 		var linkHeaderDelim = "";
+		var paginationQs    = _paginationQueryString( resolvedPaginationMode );
 
 		if ( result.nextPage ) {
-			var nextLink = event.buildLink( linkto="api.#handler#.entity.#arguments.entity#", queryString="pageSize=#arguments.pageSize#&page=#result.nextPage#" );
+			var nextLink = event.buildLink( linkto="api.#handler#.entity.#arguments.entity#", queryString="#paginationQs#&pageSize=#arguments.pageSize#&page=#result.nextPage#" );
 			if ( !isEmptyString( filterQs ) ) {
 				nextLink &= "#filterQs#";
 			}
@@ -74,7 +93,7 @@ component {
 			linkHeaderDelim = ", ";
 		}
 		if ( result.prevPage ) {
-			var prevLink = event.buildLink( linkto="api.#handler#.entity.#arguments.entity#", queryString="pageSize=#arguments.pageSize#&page=#result.prevPage#" );
+			var prevLink = event.buildLink( linkto="api.#handler#.entity.#arguments.entity#", queryString="#paginationQs#&pageSize=#arguments.pageSize#&page=#result.prevPage#" );
 			if ( !isEmptyString( filterQs ) ) {
 				prevLink &= "#filterQs#";
 			}
@@ -95,6 +114,7 @@ component {
 		, required struct  filters
 		, required string  filterQs
 		, required string  handler
+		, required string  paginationMode
 		, required any     restResponse
 	) {
 		var result = "";
@@ -119,13 +139,18 @@ component {
 		restResponse.setData( result.records );
 
 		if ( Len( result.nextCursor ) ) {
-			var nextLink = event.buildLink( linkto="api.#arguments.handler#.entity.#arguments.entity#", queryString="pageSize=#arguments.pageSize#&cursor=#URLEncodedFormat( result.nextCursor )#" );
+			var paginationQs = _paginationQueryString( arguments.paginationMode );
+			var nextLink     = event.buildLink( linkto="api.#arguments.handler#.entity.#arguments.entity#", queryString="#paginationQs#&pageSize=#arguments.pageSize#&cursor=#URLEncodedFormat( result.nextCursor )#" );
 			if ( !isEmptyString( arguments.filterQs ) ) {
 				nextLink &= "#arguments.filterQs#";
 			}
 
 			restResponse.setHeader( "Link", "<#nextLink#>; rel=""next""" );
 		}
+	}
+
+	private string function _paginationQueryString( required string paginationMode ) {
+		return "paginationMode=#arguments.paginationMode#";
 	}
 
 	private void function post( required string entity ) {

--- a/i18n/dataapi.properties
+++ b/i18n/dataapi.properties
@@ -3,7 +3,7 @@ api.description=API allowing access to data stored in the Preside system.
 api.version=1.0.0
 
 trait.pagination.title=Pagination
-trait.pagination.intro=List endpoints (`GET /entity/{entity}/`) are paginated. The pagination strategy can vary per entity; the strategies in use by this API are described below.
+trait.pagination.intro=List endpoints (`GET /entity/{entity}/`) are paginated. Use the `paginationMode` query parameter to choose a pagination strategy per request; if omitted, the default for the entity or API namespace is used. The available strategies for this API are described below.
 trait.pagination.full.description=**Full (page based, with total count)**\n\nPagination is performed with two query parameters, `page` and `pageSize`. If omitted, these will default to `1` and `100` respectively.\n\nWhen returning a successful response, the API will set three pagination related headers:\n\n1. `X-Total-Records`: The total number of records in the recordset\n2. `X-Total-Pages`: The total number of paginated pages in the recordset (based on the `pageSize`)\n3. `Link`: Links to _next_ and _previous_ URLs to use when fetching the previous or next page of results. In the form: `<{nexthref}>; rel="next", <{prevhref}>; rel="prev"`
 trait.pagination.offset.description=**Offset (page based, no total count)**\n\nPagination is performed with the `page` and `pageSize` query parameters (defaulting to `1` and `100`). No total record count is calculated, so the `X-Total-Records` and `X-Total-Pages` headers are _not_ returned. A `Link` header is still provided with _next_ and _previous_ URLs where applicable, in the form: `<{nexthref}>; rel="next", <{prevhref}>; rel="prev"`.
 trait.pagination.cursor.description=**Cursor (keyset)**\n\nPagination is performed with a `pageSize` query parameter and an opaque `cursor` query parameter. To fetch the first page, omit the `cursor`. Each successful response includes a `Link` header containing the URL for the _next_ page when more records are available, in the form: `<{nexthref}>; rel="next"`. Follow this link to page through the results. Navigation is forward only and no total record count is returned.
@@ -56,7 +56,8 @@ operation.queue.batch.delete.schema.removed=Number of items removed from the que
 operation.queue.batch.delete.post.body.description=Array of queue item IDs (UUID strings).
 
 operation.get.description=Used to fetch **{1}** records from the system.
-operation.get.params.page=For pagination; the page number to fetch. Default is 1.
+operation.get.params.paginationMode=Pagination strategy to use for this request. One of `{1}`. Default is `{2}` when omitted.
+operation.get.params.page=For page based pagination (`full` and `offset` modes); the page number to fetch. Default is 1. Ignored when `paginationMode` is `cursor`.
 operation.get.params.cursor=For cursor (keyset) pagination; the opaque cursor returned in the `Link` header of the previous response. Omit to fetch the first page.
 operation.get.params.pageSize=For pagination; the number of records per page. Default is 100.
 operation.get.params.fields=Comma separated list of fields to fetch per record. Default is all fields. Possible values: [`{2}`].

--- a/services/DataApiConfigurationService.cfc
+++ b/services/DataApiConfigurationService.cfc
@@ -66,39 +66,86 @@ component {
 		return _entityConfigOption( arguments.entity, "paginationMode", DEFAULT_PAGINATION_MODE );
 	}
 
+	public string function getEntityDefaultPaginationMode( required string entity ) {
+		var defaultMode = getEntityPaginationMode( arguments.entity );
+		var allowed     = getEntityAllowedPaginationModes( arguments.entity );
+
+		if ( ArrayFindNoCase( allowed, defaultMode ) ) {
+			return defaultMode;
+		}
+
+		return allowed[ 1 ];
+	}
+
 	public boolean function entityUsesCursorPagination( required string entity ) {
-		return getEntityPaginationMode( arguments.entity ) == VALID_PAGINATION_MODES.CURSOR;
+		return paginationModeUsesCursor( getEntityDefaultPaginationMode( arguments.entity ) );
 	}
 
 	public boolean function entityCountsTotalRecords( required string entity ) {
-		return getEntityPaginationMode( arguments.entity ) == VALID_PAGINATION_MODES.FULL;
+		return paginationModeCountsTotalRecords( getEntityDefaultPaginationMode( arguments.entity ) );
+	}
+
+	public boolean function paginationModeUsesCursor( required string mode ) {
+		return LCase( arguments.mode ) == VALID_PAGINATION_MODES.CURSOR;
+	}
+
+	public boolean function paginationModeCountsTotalRecords( required string mode ) {
+		return LCase( arguments.mode ) == VALID_PAGINATION_MODES.FULL;
 	}
 
 	public boolean function isValidPaginationMode( required string mode ) {
 		return ArrayFindNoCase( _getValidPaginationModes(), arguments.mode ) > 0;
 	}
 
-	public array function getPaginationModesInUse( string namespace=_getDataApiNamespace() ) {
+	public array function getNamespaceAllowedPaginationModes( string namespace=_getDataApiNamespace() ) {
 		var args     = arguments;
-		var cacheKey = "getPaginationModesInUse" & args.namespace;
+		var cacheKey = "getNamespaceAllowedPaginationModes" & args.namespace;
 
 		return _simpleLocalCache( cacheKey, function(){
-			var entities = getEntities( args.namespace );
-			var inUse    = {};
+			var configured = getDefaultConfigForApiNamespace( "allowedPaginationModes", args.namespace, [] );
 
-			for( var entityName in entities ) {
-				inUse[ entities[ entityName ].paginationMode ?: DEFAULT_PAGINATION_MODE ] = true;
-			}
-
-			var ordered = [];
-			for( var mode in _getValidPaginationModes() ) {
-				if ( inUse.keyExists( mode ) ) {
-					ArrayAppend( ordered, mode );
-				}
-			}
-
-			return ordered;
+			return _normalizeAllowedPaginationModes( configured );
 		} );
+	}
+
+	public array function getEntityAllowedPaginationModes( required string entity ) {
+		var args     = arguments;
+		var cacheKey = "getEntityAllowedPaginationModes" & _getDataApiNamespace() & args.entity;
+
+		return _simpleLocalCache( cacheKey, function(){
+			var entities = getEntities();
+
+			if ( !entities.keyExists( args.entity ) ) {
+				return getNamespaceAllowedPaginationModes();
+			}
+
+			return entities[ args.entity ].allowedPaginationModes;
+		} );
+	}
+
+	public array function getPaginationModesInUse( string namespace=_getDataApiNamespace() ) {
+		return getNamespaceAllowedPaginationModes( arguments.namespace );
+	}
+
+	public string function resolvePaginationMode( required string entity, string requestedMode="" ) {
+		var allowedModes = getEntityAllowedPaginationModes( arguments.entity );
+		var defaultMode  = getEntityDefaultPaginationMode( arguments.entity );
+
+		if ( !Len( Trim( arguments.requestedMode ) ) ) {
+			return defaultMode;
+		}
+
+		var mode = LCase( Trim( arguments.requestedMode ) );
+
+		if ( !isValidPaginationMode( mode ) ) {
+			throw( type="dataApiPaginationMode.invalid", message="The supplied pagination mode is not valid." );
+		}
+
+		if ( ArrayFindNoCase( allowedModes, mode ) == 0 ) {
+			throw( type="dataApiPaginationMode.notAllowed", message="The supplied pagination mode is not allowed for this entity." );
+		}
+
+		return mode;
 	}
 
 	public string function entityResponseTypeOnInsert( required string entity ) {
@@ -347,7 +394,10 @@ component {
 					var allowQueue             = poService.getObjectAttribute( objectName, "dataApiQueueEnabled#namespace#", true );
 					var queueName              = poService.getObjectAttribute( objectName, "dataApiQueue#namespace#", "default" );
 					var category               = poService.getObjectAttribute( objectName, "dataApiCategory#namespace#", "" );
-					var paginationMode         = poService.getObjectAttribute( objectName, "dataApiPaginationMode#namespace#", getDefaultConfigForApiNamespace( "paginationMode", args.namespace, DEFAULT_PAGINATION_MODE ) );
+					var paginationMode               = poService.getObjectAttribute( objectName, "dataApiPaginationMode#namespace#", getDefaultConfigForApiNamespace( "paginationMode", args.namespace, DEFAULT_PAGINATION_MODE ) );
+					var namespaceAllowed             = _normalizeAllowedPaginationModes( getDefaultConfigForApiNamespace( "allowedPaginationModes", args.namespace, [] ) );
+					var entityAllowedPaginationModes = poService.getObjectAttribute( objectName, "dataApiAllowedPaginationModes#namespace#", "" );
+					var allowedPaginationModes       = Len( Trim( entityAllowedPaginationModes ) ) ? _intersectPaginationModes( namespaceAllowed, entityAllowedPaginationModes ) : namespaceAllowed;
 
 					entities[ entityName ] = {
 						  objectName             = objectName
@@ -363,6 +413,7 @@ component {
 						, allowQueue             = _isTrue( allowQueue    )
 						, queueName              = queueName
 						, paginationMode         = isValidPaginationMode( paginationMode ) ? LCase( paginationMode ) : DEFAULT_PAGINATION_MODE
+						, allowedPaginationModes = _normalizeAllowedPaginationModes( allowedPaginationModes )
 					};
 
 					if ( !entities[ entityName ].selectFields.len() ) {
@@ -747,6 +798,43 @@ component {
 
 	public array function _getValidPaginationModes() {
 		return [ VALID_PAGINATION_MODES.FULL, VALID_PAGINATION_MODES.OFFSET, VALID_PAGINATION_MODES.CURSOR ];
+	}
+
+	private array function _normalizeAllowedPaginationModes( required any configuredModes ) {
+		var modes = [];
+
+		if ( IsArray( arguments.configuredModes ) ) {
+			modes = arguments.configuredModes;
+		} else if ( IsSimpleValue( arguments.configuredModes ) && Len( Trim( arguments.configuredModes ) ) ) {
+			modes = ListToArray( LCase( Trim( arguments.configuredModes ) ) );
+		}
+
+		if ( !modes.len() ) {
+			return _getValidPaginationModes();
+		}
+
+		var allowed = [];
+
+		for ( var mode in _getValidPaginationModes() ) {
+			if ( ArrayFindNoCase( modes, mode ) ) {
+				ArrayAppend( allowed, mode );
+			}
+		}
+
+		return allowed.len() ? allowed : _getValidPaginationModes();
+	}
+
+	private array function _intersectPaginationModes( required array left, required any right ) {
+		var normalizedRight = _normalizeAllowedPaginationModes( arguments.right );
+		var intersected     = [];
+
+		for ( var mode in _normalizeAllowedPaginationModes( arguments.left ) ) {
+			if ( ArrayFindNoCase( normalizedRight, mode ) ) {
+				ArrayAppend( intersected, mode );
+			}
+		}
+
+		return intersected.len() ? intersected : normalizedRight;
 	}
 
 	private any function _simpleLocalCache( required string cacheKey, required any generator ) {

--- a/services/DataApiConfigurationService.cfc
+++ b/services/DataApiConfigurationService.cfc
@@ -809,7 +809,7 @@ component {
 			modes = ListToArray( LCase( Trim( arguments.configuredModes ) ) );
 		}
 
-		if ( !modes.len() ) {
+		if ( !ArrayLen( modes ) ) {
 			return _getValidPaginationModes();
 		}
 

--- a/services/DataApiService.cfc
+++ b/services/DataApiService.cfc
@@ -48,9 +48,11 @@ component {
 		, required numeric page
 		, required numeric pageSize
 		, required array   fields
-		,          struct  filters = {}
+		,          struct  filters        = {}
+		,          string  paginationMode = ""
 	) {
-		var countTotalRecords = _getConfigService().entityCountsTotalRecords( arguments.entity );
+		var mode              = Len( Trim( arguments.paginationMode ) ) ? arguments.paginationMode : _getConfigService().getEntityDefaultPaginationMode( arguments.entity );
+		var countTotalRecords = _getConfigService().paginationModeCountsTotalRecords( mode );
 		var args              = {
 			  maxRows      = pageSize
 			, startRow     = ( ( arguments.page - 1 ) * arguments.pageSize ) + 1

--- a/services/DataApiSpecService.cfc
+++ b/services/DataApiSpecService.cfc
@@ -309,9 +309,9 @@ component {
 					, in          = "query"
 					, required    = false
 					, description = _i18nNamespaced(
-						  uri="dataapi:operation.get.params.paginationMode"
-						, defaultValue=""
-						, data=[ allowedPaginationModes.toList( ", " ), defaultPaginationMode ]
+						  uri          = "dataapi:operation.get.params.paginationMode"
+						, defaultValue = ""
+						, data         = [ allowedPaginationModes.toList( ", " ), defaultPaginationMode ]
 					  )
 					, schema      = { type="string", enum=allowedPaginationModes, default=defaultPaginationMode }
 				}, {

--- a/services/DataApiSpecService.cfc
+++ b/services/DataApiSpecService.cfc
@@ -301,27 +301,37 @@ component {
 			spec.components.schemas[ entityName ] = _getEntitySchema( entityName );
 
 			if ( configService.entityVerbIsSupported( entityName, "get" ) ) {
-				var fieldsFilterList = configService.getSelectFields( entityName, true ).toList( ", " );
-				var isCursorMode     = configService.entityUsesCursorPagination( entityName );
-				var firstParam       = isCursorMode ? {
-					name        = "cursor"
-				  , in          = "query"
-				  , required    = false
-				  , description = _i18nNamespaced( uri="dataapi:operation.get.params.cursor", defaultValue="", data=[ entityTag ] )
-				  , schema      = { type="string" }
-				} : {
+				var fieldsFilterList       = configService.getSelectFields( entityName, true ).toList( ", " );
+				var allowedPaginationModes = configService.getEntityAllowedPaginationModes( entityName );
+				var defaultPaginationMode  = configService.getEntityDefaultPaginationMode( entityName );
+				var params = [{
+					  name        = "paginationMode"
+					, in          = "query"
+					, required    = false
+					, description = _i18nNamespaced(
+						  uri="dataapi:operation.get.params.paginationMode"
+						, defaultValue=""
+						, data=[ allowedPaginationModes.toList( ", " ), defaultPaginationMode ]
+					  )
+					, schema      = { type="string", enum=allowedPaginationModes, default=defaultPaginationMode }
+				}, {
 					name        = "page"
 				  , in          = "query"
 				  , required    = false
 				  , description = _i18nNamespaced( uri="dataapi:operation.get.params.page", defaultValue="", data=[ entityTag ] )
 				  , schema      = { type="integer" }
-				};
-				var params = [ firstParam, {
+				}, {
 					name        = "pageSize"
 				  , in          = "query"
 				  , required    = false
 				  , description = _i18nNamespaced( uri="dataapi:operation.get.params.pageSize", defaultValue="", data=[ entityTag ] )
 				  , schema      = { type="integer" }
+				}, {
+					name        = "cursor"
+				  , in          = "query"
+				  , required    = false
+				  , description = _i18nNamespaced( uri="dataapi:operation.get.params.cursor", defaultValue="", data=[ entityTag ] )
+				  , schema      = { type="string" }
 				},{
 					name        = "fields"
 				  , in          = "query"
@@ -357,11 +367,11 @@ component {
 					}
 				}
 
-				var getResponseHeaders = { "Link" = { "$ref"="##/components/headers/Link" } };
-				if ( configService.entityCountsTotalRecords( entityName ) ) {
-					getResponseHeaders[ "X-Total-Records" ] = { "$ref"="##/components/headers/XTotalRecords" };
-					getResponseHeaders[ "X-Total-Pages"   ] = { "$ref"="##/components/headers/XTotalPages" };
-				}
+				var getResponseHeaders = {
+					  "X-Total-Records" = { "$ref"="##/components/headers/XTotalRecords" }
+					, "X-Total-Pages"   = { "$ref"="##/components/headers/XTotalPages" }
+					, "Link"            = { "$ref"="##/components/headers/Link" }
+				};
 
 				spec.paths[ "/entity/#entityName#/" ].get = {
 					  tags = [ entityTag ]

--- a/tests/BaseTest.cfc
+++ b/tests/BaseTest.cfc
@@ -15,7 +15,8 @@ component extends="testbox.system.BaseSpec" {
 			, skipValidationOnUpdate = false
 			, responseTypeOnInsert   = "record"
 			, responseTypeOnUpdate   = "record"
-			, paginationMode         = "full"
+			, paginationMode           = "full"
+			, allowedPaginationModes   = []
 		};
 	}
 

--- a/tests/fixtures/DataApiTestFixtures.cfc
+++ b/tests/fixtures/DataApiTestFixtures.cfc
@@ -52,10 +52,10 @@ component {
 			  }
 			, restricted_contact = {
 				  attributes = {
-					  dataApiEnabled               = true
-					, dataApiEntityName            = "restricted_contact"
+					  dataApiEnabled                = true
+					, dataApiEntityName             = "restricted_contact"
 					, dataApiAllowedPaginationModes = "cursor"
-					, dbFieldlist                  = "id,label,datemodified,datecreated"
+					, dbFieldlist                   = "id,label,datemodified,datecreated"
 				  }
 				, properties = {
 					  id           = { type="string", dbtype="varchar" , required=true }

--- a/tests/fixtures/DataApiTestFixtures.cfc
+++ b/tests/fixtures/DataApiTestFixtures.cfc
@@ -50,6 +50,20 @@ component {
 					, datecreated  = { type="date"  , dbtype="datetime" }
 				  }
 			  }
+			, restricted_contact = {
+				  attributes = {
+					  dataApiEnabled               = true
+					, dataApiEntityName            = "restricted_contact"
+					, dataApiAllowedPaginationModes = "cursor"
+					, dbFieldlist                  = "id,label,datemodified,datecreated"
+				  }
+				, properties = {
+					  id           = { type="string", dbtype="varchar" , required=true }
+					, label        = { type="string", dbtype="varchar" }
+					, datemodified = { type="date"  , dbtype="datetime" }
+					, datecreated  = { type="date"  , dbtype="datetime" }
+				  }
+			  }
 			, get_only_contact = {
 				  attributes = {
 					  dataApiEnabled    = true

--- a/tests/unit/DataApiConfigurationServiceTest.cfc
+++ b/tests/unit/DataApiConfigurationServiceTest.cfc
@@ -96,6 +96,59 @@ component extends="tests.BaseTest" {
 				expect( svc.getEntityPaginationMode( "cursor_contact" ) ).toBe( "cursor" );
 			} );
 
+			it( "should allow all pagination modes by default", function(){
+				var svc = _getConfigService();
+
+				expect( svc.getNamespaceAllowedPaginationModes() ).toBe( [ "full", "offset", "cursor" ] );
+				expect( svc.getEntityAllowedPaginationModes( "contact" ) ).toBe( [ "full", "offset", "cursor" ] );
+				expect( svc.getPaginationModesInUse() ).toBe( [ "full", "offset", "cursor" ] );
+			} );
+
+			it( "should restrict allowed pagination modes when configured for a namespace", function(){
+				var svc = _getConfigService(
+					  defaults = {
+						  paginationMode         = "offset"
+						, allowedPaginationModes = [ "offset", "cursor" ]
+					  }
+				);
+
+				expect( svc.getNamespaceAllowedPaginationModes() ).toBe( [ "offset", "cursor" ] );
+				expect( svc.getPaginationModesInUse() ).toBe( [ "offset", "cursor" ] );
+			} );
+
+			it( "should further restrict allowed pagination modes per entity", function(){
+				var svc = _getConfigService();
+
+				expect( svc.getEntityAllowedPaginationModes( "restricted_contact" ) ).toBe( [ "cursor" ] );
+			} );
+
+			it( "should resolve the requested pagination mode for an entity", function(){
+				var svc = _getConfigService();
+
+				expect( svc.resolvePaginationMode( "contact" ) ).toBe( "full" );
+				expect( svc.resolvePaginationMode( "contact", "cursor" ) ).toBe( "cursor" );
+				expect( svc.resolvePaginationMode( "cursor_contact" ) ).toBe( "cursor" );
+				expect( svc.resolvePaginationMode( "cursor_contact", "offset" ) ).toBe( "offset" );
+			} );
+
+			it( "should use configured namespace defaults when the client does not specify a mode", function(){
+				var svc = _getConfigService( defaults={ paginationMode="offset" } );
+
+				expect( svc.resolvePaginationMode( "contact" ) ).toBe( "offset" );
+			} );
+
+			it( "should reject invalid or disallowed pagination modes", function(){
+				var svc = _getConfigService();
+
+				expect( function(){
+					svc.resolvePaginationMode( "contact", "invalid" );
+				} ).toThrow( type="dataApiPaginationMode.invalid" );
+
+				expect( function(){
+					svc.resolvePaginationMode( "restricted_contact", "full" );
+				} ).toThrow( type="dataApiPaginationMode.notAllowed" );
+			} );
+
 			it( "should identify cursor pagination and total record counting behaviour", function(){
 				var svc = _getConfigService();
 
@@ -103,6 +156,9 @@ component extends="tests.BaseTest" {
 				expect( svc.entityUsesCursorPagination( "contact" ) ).toBeFalse();
 				expect( svc.entityCountsTotalRecords( "contact" ) ).toBeTrue();
 				expect( svc.entityCountsTotalRecords( "offset_contact" ) ).toBeFalse();
+				expect( svc.paginationModeUsesCursor( "cursor" ) ).toBeTrue();
+				expect( svc.paginationModeCountsTotalRecords( "full" ) ).toBeTrue();
+				expect( svc.paginationModeCountsTotalRecords( "offset" ) ).toBeFalse();
 			} );
 
 			it( "should list pagination modes in use for a namespace", function(){

--- a/tests/unit/DataApiI18nPropertiesTest.cfc
+++ b/tests/unit/DataApiI18nPropertiesTest.cfc
@@ -13,6 +13,7 @@ component extends="testbox.system.BaseSpec" {
 				var fixtures = new tests.fixtures.DataApiTestFixtures();
 				var bundle   = fixtures.loadI18nProperties();
 
+				expect( bundle[ "trait.pagination.intro" ] ).toInclude( "paginationMode" );
 				expect( bundle[ "trait.pagination.full.description" ] ).toInclude( "X-Total-Records" );
 				expect( bundle[ "trait.pagination.full.description" ] ).toInclude( "X-Total-Pages" );
 				expect( bundle[ "trait.pagination.full.description" ] ).toInclude( "pageSize" );
@@ -35,6 +36,14 @@ component extends="testbox.system.BaseSpec" {
 				expect( bundle[ "trait.pagination.cursor.description" ] ).toInclude( "cursor" );
 				expect( bundle[ "trait.pagination.cursor.description" ] ).toInclude( "forward only" );
 				expect( Len( bundle[ "trait.pagination.cursor.description" ] ) ).toBeGT( 100 );
+			} );
+
+			it( "should clarify that the page parameter is ignored in cursor pagination mode", function(){
+				var fixtures = new tests.fixtures.DataApiTestFixtures();
+				var bundle   = fixtures.loadI18nProperties();
+
+				expect( bundle[ "operation.get.params.page" ] ).toInclude( "cursor" );
+				expect( bundle[ "operation.get.params.page" ] ).toInclude( "Ignored" );
 			} );
 
 			it( "should preserve multiline error handling documentation including the JSON example", function(){

--- a/tests/unit/DataApiServiceTest.cfc
+++ b/tests/unit/DataApiServiceTest.cfc
@@ -159,6 +159,50 @@ component extends="tests.BaseTest" {
 				expect( ArrayLen( result.records ) ).toBe( 2 );
 				expect( result.nextPage ).toBe( 2 );
 			} );
+
+			it( "should honour a requested pagination mode override", function(){
+				var configSvc = _getConfigService();
+				var svc       = _getDataApiService( configSvc );
+				var dao       = _sequentialSelectDataMock( [
+					  [ { id=CreateUUID(), label="One", datemodified=Now(), datecreated=Now(), is_active=true, status="" } ]
+					, 5
+				] );
+
+				svc.$( "$getPresideObject" ).$args( "test_contact" ).$results( dao );
+
+				var result = svc.getPaginatedRecords(
+					  entity         = "contact"
+					, page           = 1
+					, pageSize       = 2
+					, fields         = []
+					, filters        = {}
+					, paginationMode = "full"
+				);
+
+				expect( result.totalCount ).toBe( 5 );
+				expect( result.totalPages ).toBe( 3 );
+
+				dao = _mockPresideObject( "test_contact" );
+				dao.$( "selectData" ).$results( [
+					  { id=CreateUUID(), label="One" }
+					, { id=CreateUUID(), label="Two" }
+					, { id=CreateUUID(), label="Three" }
+				] );
+				svc.$( "$getPresideObject" ).$args( "test_contact" ).$results( dao );
+
+				result = svc.getPaginatedRecords(
+					  entity         = "contact"
+					, page           = 1
+					, pageSize       = 2
+					, fields         = []
+					, filters        = {}
+					, paginationMode = "offset"
+				);
+
+				expect( result ).notToHaveKey( "totalCount" );
+				expect( result ).notToHaveKey( "totalPages" );
+				expect( ArrayLen( result.records ) ).toBe( 2 );
+			} );
 		} );
 
 		describe( "getCursorRecords()", function(){

--- a/tests/unit/DataApiSpecServiceTest.cfc
+++ b/tests/unit/DataApiSpecServiceTest.cfc
@@ -51,9 +51,60 @@ component extends="tests.BaseTest" {
 				}
 
 				expect( paginationTag.description ).toInclude( bundle[ "trait.pagination.intro" ] );
+				expect( paginationTag.description ).toInclude( "paginationMode" );
 				expect( paginationTag.description ).toInclude( "X-Total-Records" );
 				expect( paginationTag.description ).toInclude( "cursor" );
 				expect( paginationTag.description ).toInclude( "pageSize" );
+			} );
+
+			it( "should expose paginationMode and page/cursor params on paginated GET endpoints", function(){
+				var bundle    = _fixtures().loadI18nProperties();
+				var configSvc = _getConfigService();
+				var apiSvc    = _getDataApiService( configSvc, "", bundle );
+				var svc       = _getSpecService( configSvc, apiSvc, "", bundle );
+				var spec      = svc.getSpec();
+				var params    = spec.paths[ "/entity/contact/" ].get.parameters;
+				var paramNames = params.map( function( param ){ return param.name; } );
+
+				expect( paramNames ).toInclude( "paginationMode" );
+				expect( paramNames ).toInclude( "page" );
+				expect( paramNames ).toInclude( "cursor" );
+				expect( paramNames ).toInclude( "pageSize" );
+
+				var paginationParam = {};
+				for ( var param in params ) {
+					if ( param.name == "paginationMode" ) {
+						paginationParam = param;
+						break;
+					}
+				}
+
+				expect( paginationParam.schema.enum ).toInclude( "full" );
+				expect( paginationParam.schema.enum ).toInclude( "offset" );
+				expect( paginationParam.schema.enum ).toInclude( "cursor" );
+				expect( paginationParam.schema.default ).toBe( "full" );
+			} );
+
+			it( "should restrict paginationMode options in docs when allowed modes are configured", function(){
+				var bundle    = _fixtures().loadI18nProperties();
+				var configSvc = _getConfigService(
+					  defaults = { allowedPaginationModes=[ "offset", "cursor" ], paginationMode="offset" }
+				);
+				var apiSvc    = _getDataApiService( configSvc, "", bundle );
+				var svc       = _getSpecService( configSvc, apiSvc, "", bundle );
+				var spec      = svc.getSpec();
+				var params    = spec.paths[ "/entity/contact/" ].get.parameters;
+				var paginationParam = {};
+
+				for ( var param in params ) {
+					if ( param.name == "paginationMode" ) {
+						paginationParam = param;
+						break;
+					}
+				}
+
+				expect( paginationParam.schema.enum ).toBe( [ "offset", "cursor" ] );
+				expect( paginationParam.schema.default ).toBe( "offset" );
 			} );
 
 			it( "should include common pagination headers and validation schema components", function(){


### PR DESCRIPTION
Allow client applications to specify pagination mode in paginated GET api calls. This allows for rolling out the performance changes in 3.8 without having to update individual application configurations to change the pagination mode while maintaining backward compatibility.