### PR TITLE
DATAAPI-53 relative date filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,39 @@ component {
 * The primary sort column should be **non-null** and have **second (or coarser) precision** for fully reliable results. The default `datemodified`/`datecreated` fields satisfy this. A custom `dataApiSortOrder` pointing at a nullable or sub-second column may skip or duplicate rows at page boundaries.
 * The cursor is opaque and stateless. If a row's sort value changes between requests, the client simply continues from the encoded position (acceptable for sync style consumers).
 
+## Filtering
+
+Paginated GET requests support simple query-string filters on fields listed by `dataApiFilterFields` (defaults include foreign keys, boolean, enum and date fields):
+
+```
+GET /api/data/v1/entity/contact/?filter.is_active=true
+```
+
+### Date filters
+
+Date and datetime fields also accept inclusive range bounds:
+
+```
+GET /api/data/v1/entity/contact/?filter.datemodified.min=2024-01-01&filter.datemodified.max=2024-12-31T23:59:59
+```
+
+Relative (dynamic) date expressions are also supported, using a Grafana-compatible syntax evaluated against the server clock at request time. This is useful for automation platforms that need to pull recently changed data without calculating absolute timestamps:
+
+```
+GET /api/data/v1/entity/contact/?filter.datemodified.min=now-7d
+GET /api/data/v1/entity/contact/?filter.datecreated.min=now-1M&filter.datecreated.max=now
+GET /api/data/v1/entity/contact/?filter.datemodified.min=now/d
+```
+
+Supported forms:
+
+* `now` — the current date/time
+* `now-7d` / `now+1h` — offset from now (`+` or `-` and a numeric amount)
+* `now/d` — round to the start (or end, for `.max`) of a unit
+* `now-1d/d` — offset then round
+
+Units: `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks), `M` (months), `y` (years). Expressions are case-insensitive for the `now` token; unit letters are case-sensitive (`m` vs `M`). Absolute ISO/SQL date strings continue to work as before. Invalid relative expressions return HTTP `400`.
+
 ## Custom renderers
 
 If you specify a non-default renderer for an object property, it will be rendered using Preside's content rendering system. For example, the following property definition specifies a `myCustomRenderer` renderer:

--- a/handlers/rest-apis/data/v1/WholeEntity.cfc
+++ b/handlers/rest-apis/data/v1/WholeEntity.cfc
@@ -44,13 +44,22 @@ component {
 			return;
 		}
 
-		var result = dataApiService.getPaginatedRecords(
-			  entity   = arguments.entity
-			, page     = arguments.page
-			, pageSize = arguments.pageSize
-			, fields   = ListToArray( arguments.fields )
-			, filters  = filters
-		);
+		try {
+			var result = dataApiService.getPaginatedRecords(
+				  entity   = arguments.entity
+				, page     = arguments.page
+				, pageSize = arguments.pageSize
+				, fields   = ListToArray( arguments.fields )
+				, filters  = filters
+			);
+		} catch( "dataApi.relativeDate.invalid" e ) {
+			restResponse.setError(
+				  errorCode = 400
+				, title     = "Bad request"
+				, message   = e.message
+			);
+			return;
+		}
 
 		restResponse.setData( result.records );
 
@@ -107,7 +116,7 @@ component {
 				, cursor   = arguments.cursor
 				, filters  = arguments.filters
 			);
-		} catch( "dataApiCursor.invalid" e ) {
+		} catch( "dataApiCursor.invalid dataApi.relativeDate.invalid" e ) {
 			restResponse.setError(
 				  errorCode = 400
 				, title     = "Bad request"

--- a/handlers/rest-apis/data/v1/WholeEntity.cfc
+++ b/handlers/rest-apis/data/v1/WholeEntity.cfc
@@ -116,7 +116,14 @@ component {
 				, cursor   = arguments.cursor
 				, filters  = arguments.filters
 			);
-		} catch( "dataApiCursor.invalid dataApi.relativeDate.invalid" e ) {
+		} catch( "dataApiCursor.invalid" e ) {
+			restResponse.setError(
+				  errorCode = 400
+				, title     = "Bad request"
+				, message   = e.message
+			);
+			return;
+		} catch( "dataApi.relativeDate.invalid" e ) {
 			restResponse.setError(
 				  errorCode = 400
 				, title     = "Bad request"

--- a/i18n/dataapi.properties
+++ b/i18n/dataapi.properties
@@ -98,6 +98,8 @@ operation.delete.params.recordId=ID of the **{1}** record you wish to delete
 field.id.description=Primary key of the record.
 field.datemodified.description=Date that the record was last modified.
 field.datecreated.description=Date that the record was created.
+field.date.filter.min.description=Minimum value (inclusive) for this date field. Accepts an absolute date/datetime or a relative expression such as now, now-7d or now/d.
+field.date.filter.max.description=Maximum value (inclusive) for this date field. Accepts an absolute date/datetime or a relative expression such as now, now-7d or now/d.
 
 
 auth.configuration.no.users=No users are currently configured to access this API. Add a user to get started.

--- a/services/DataApiService.cfc
+++ b/services/DataApiService.cfc
@@ -6,13 +6,19 @@ component {
 
 // CONSTRUCTOR
 	/**
-	 * @presideRestService.inject presideRestService
-	 * @configService.inject      dataApiConfigurationService
+	 * @presideRestService.inject            presideRestService
+	 * @configService.inject                 dataApiConfigurationService
+	 * @relativeDateExpressionService.inject relativeDateExpressionService
 	 *
 	 */
-	public any function init( required any presideRestService, required any configService ) {
+	public any function init(
+		  required any presideRestService
+		, required any configService
+		, required any relativeDateExpressionService
+	) {
 		_setPresideRestService( arguments.presideRestService );
 		_setConfigService( arguments.configService );
+		_setRelativeDateExpressionService( arguments.relativeDateExpressionService );
 
 		return this;
 	}
@@ -695,37 +701,69 @@ component {
 			var filterFields  = configService.getFilterFields( arguments.entity );
 
 			for( var field in filterFields ) {
-				var propName  = configService.getPropertyNameFromFieldAlias( arguments.entity, field );
-				var fieldType = $getPresideObjectService().getObjectPropertyAttribute( objectName, propName, "dbtype" );
+				var propName    = configService.getPropertyNameFromFieldAlias( arguments.entity, field );
+				var fieldType   = $getPresideObjectService().getObjectPropertyAttribute( objectName, propName, "dbtype" );
+				var isDateField = ReFindNoCase( "^date", fieldType );
 
 				if ( StructKeyExists( arguments.filters, field ) || StructKeyExists( arguments.filters, propName ) ) {
-					args.filter[ propName ] = arguments.filters[ field ] ?: arguments.filters[ propName ];
+					var equalityValue = arguments.filters[ field ] ?: arguments.filters[ propName ];
+
+					if ( isDateField ) {
+						equalityValue = _resolveDateFilterValue( equalityValue, fieldType, "floor" );
+					}
+
+					args.filter[ propName ] = equalityValue;
 				}
 
-				if ( ReFindNoCase( "^date", fieldType ) ) {
+				if ( isDateField ) {
 					if ( StructKeyExists( arguments.filters, field & ".min" ) || StructKeyExists( arguments.filters, propName & ".min" ) ) {
-						var value = arguments.filters[ field & ".min" ] ?: arguments.filters[ propName & ".min" ];
+						var minValue = arguments.filters[ field & ".min" ] ?: arguments.filters[ propName & ".min" ];
+						minValue = _resolveDateFilterValue( minValue, fieldType, "floor" );
 						ArrayAppend( args.extraFilters, {
 							  filter       = "#dbAdapter.escapeEntity( '#objectName#.#propName#' )# >= :#propName#__min"
 							, filterParams = { "#propName#__min" = {
 								  type  = dbAdapter.sqlDataTypeToCfSqlDatatype( fieldType )
-								, value = value
+								, value = minValue
 							  } }
 						} );
 					}
 					if ( StructKeyExists( arguments.filters, field & ".max" ) || StructKeyExists( arguments.filters, propName & ".max" ) ) {
-						var value = arguments.filters[ field & ".max" ] ?: arguments.filters[ propName & ".max" ];
+						var maxValue = arguments.filters[ field & ".max" ] ?: arguments.filters[ propName & ".max" ];
+						maxValue = _resolveDateFilterValue( maxValue, fieldType, "ceil" );
 						ArrayAppend( args.extraFilters, {
 							  filter       = "#dbAdapter.escapeEntity( '#objectName#.#propName#' )# <= :#propName#__max"
 							, filterParams = { "#propName#__max" = {
 								  type  = dbAdapter.sqlDataTypeToCfSqlDatatype( fieldType )
-								, value = value
+								, value = maxValue
 							  } }
 						} );
 					}
 				}
 			}
 		}
+	}
+
+	private any function _resolveDateFilterValue(
+		  required any    value
+		, required string fieldType
+		, required string roundDirection
+	) {
+		var relativeDateService = _getRelativeDateExpressionService();
+
+		if ( !IsSimpleValue( arguments.value ) || !relativeDateService.isRelativeExpression( arguments.value ) ) {
+			return arguments.value;
+		}
+
+		var resolved = relativeDateService.parse(
+			  expression     = arguments.value
+			, roundDirection = arguments.roundDirection
+		);
+
+		if ( arguments.fieldType == "date" ) {
+			return DateFormat( resolved, "yyyy-mm-dd" );
+		}
+
+		return DateTimeFormat( resolved, "yyyy-mm-dd HH:nn:ss" );
 	}
 
 // GETTERS AND SETTERS
@@ -741,6 +779,13 @@ component {
 	}
 	private void function _setConfigService( required any configService ) {
 		_configService = arguments.configService;
+	}
+
+	private any function _getRelativeDateExpressionService() {
+		return _relativeDateExpressionService;
+	}
+	private void function _setRelativeDateExpressionService( required any relativeDateExpressionService ) {
+		_relativeDateExpressionService = arguments.relativeDateExpressionService;
 	}
 
 }

--- a/services/DataApiSpecService.cfc
+++ b/services/DataApiSpecService.cfc
@@ -331,11 +331,13 @@ component {
 				} ];
 
 				for( var field in configService.getFilterFields( entityName ) ) {
+					var fieldFilterDescription = _i18nNamespaced( uri="dataapi:operation.#entityName#.get.params.fields.#field#.description", defaultValue=_i18nNamespaced( uri=basei18n & "field.#field#.help", defaultValue=_i18nNamespaced( uri="dataapi:field.#field#.description", defaultValue="" ) ) );
+
 					params.append( {
 						  name        = "filter.#field#"
 						, in          = "query"
 						, required    = false
-						, description = _i18nNamespaced( uri="dataapi:operation.#entityName#.get.params.fields.#field#.description", defaultValue=_i18nNamespaced( uri=basei18n & "field.#field#.help", defaultValue=_i18nNamespaced( uri="dataapi:field.#field#.description", defaultValue="" ) ) )
+						, description = fieldFilterDescription
 						, schema      = _getFieldSchema( entityName, field )
 					} );
 
@@ -344,14 +346,14 @@ component {
 							  name        = "filter.#field#.min"
 							, in          = "query"
 							, required    = false
-							, description = _i18nNamespaced( uri="dataapi:operation.#entityName#.get.params.fields.#field#.description", defaultValue=_i18nNamespaced( uri=basei18n & "field.#field#.help", defaultValue=_i18nNamespaced( uri="dataapi:field.#field#.description", defaultValue="" ) ) )
+							, description = _i18nNamespaced( uri="dataapi:operation.#entityName#.get.params.fields.#field#.min.description", defaultValue=_i18nNamespaced( uri="dataapi:field.date.filter.min.description", defaultValue=fieldFilterDescription ) )
 							, schema      = _getFieldSchema( entityName, field )
 						} );
 						params.append( {
 							  name        = "filter.#field#.max"
 							, in          = "query"
 							, required    = false
-							, description = _i18nNamespaced( uri="dataapi:operation.#entityName#.get.params.fields.#field#.description", defaultValue=_i18nNamespaced( uri=basei18n & "field.#field#.help", defaultValue=_i18nNamespaced( uri="dataapi:field.#field#.description", defaultValue="" ) ) )
+							, description = _i18nNamespaced( uri="dataapi:operation.#entityName#.get.params.fields.#field#.max.description", defaultValue=_i18nNamespaced( uri="dataapi:field.date.filter.max.description", defaultValue=fieldFilterDescription ) )
 							, schema      = _getFieldSchema( entityName, field )
 						} );
 					}

--- a/services/RelativeDateExpressionService.cfc
+++ b/services/RelativeDateExpressionService.cfc
@@ -1,0 +1,181 @@
+/**
+ * Parses Grafana-compatible relative date expressions such as now, now-7d and now/d.
+ *
+ * @presideService true
+ * @singleton      true
+ */
+component {
+
+// CONSTRUCTOR
+	public any function init() {
+		return this;
+	}
+
+// PUBLIC API METHODS
+	public boolean function isRelativeExpression( required string value ) {
+		return ReFindNoCase( "^now($|[+\-/])", Trim( arguments.value ) ) > 0;
+	}
+
+	/**
+	 * @roundDirection.hint floor (for equality / min) or ceil (for max)
+	 * @referenceDate.hint  optional fixed point in time for deterministic parsing / tests
+	 */
+	public date function parse(
+		  required string expression
+		,          string roundDirection = "floor"
+		,          date   referenceDate  = Now()
+	) {
+		var expr = Trim( arguments.expression );
+
+		if ( !isRelativeExpression( expr ) ) {
+			_throwInvalid( arguments.expression );
+		}
+
+		var rest   = Mid( expr, 4 );
+		var result = arguments.referenceDate;
+
+		if ( Len( rest ) && Left( rest, 1 ) != "/" ) {
+			var offsetMatch = ReFind( "^([+-])(\d+)([smhdwMy])", rest, 1, true );
+
+			if ( !offsetMatch.len[ 1 ] ) {
+				_throwInvalid( arguments.expression );
+			}
+
+			var sign   = Mid( rest, offsetMatch.pos[ 2 ], offsetMatch.len[ 2 ] );
+			var amount = Val( Mid( rest, offsetMatch.pos[ 3 ], offsetMatch.len[ 3 ] ) );
+			var unit   = Mid( rest, offsetMatch.pos[ 4 ], offsetMatch.len[ 4 ] );
+
+			if ( !_isValidUnit( unit ) ) {
+				_throwInvalid( arguments.expression );
+			}
+
+			result = DateAdd( _toDateAddPart( unit ), sign == "-" ? -amount : amount, result );
+			rest   = Mid( rest, offsetMatch.pos[ 1 ] + offsetMatch.len[ 1 ] );
+		}
+
+		if ( Len( rest ) ) {
+			var roundMatch = ReFind( "^/([smhdwMy])$", rest, 1, true );
+
+			if ( !roundMatch.len[ 1 ] ) {
+				_throwInvalid( arguments.expression );
+			}
+
+			var roundUnit = Mid( rest, roundMatch.pos[ 2 ], roundMatch.len[ 2 ] );
+
+			if ( !_isValidUnit( roundUnit ) ) {
+				_throwInvalid( arguments.expression );
+			}
+
+			result = _roundToUnit(
+				  dt        = result
+				, unit      = roundUnit
+				, direction = arguments.roundDirection == "ceil" ? "ceil" : "floor"
+			);
+		}
+
+		return result;
+	}
+
+// PRIVATE HELPERS
+	private void function _throwInvalid( required string expression ) {
+		throw(
+			  type    = "dataApi.relativeDate.invalid"
+			, message = "Invalid relative date expression: [#arguments.expression#]"
+		);
+	}
+
+	private boolean function _isValidUnit( required string unit ) {
+		return ListFind( "s,m,h,d,w,M,y", arguments.unit ) > 0;
+	}
+
+	private string function _toDateAddPart( required string unit ) {
+		if ( !Compare( arguments.unit, "M" ) ) {
+			return "m";
+		}
+
+		switch( arguments.unit ) {
+			case "s": return "s";
+			case "m": return "n";
+			case "h": return "h";
+			case "d": return "d";
+			case "w": return "ww";
+			case "y": return "yyyy";
+		}
+
+		_throwInvalid( arguments.unit );
+	}
+
+	private date function _roundToUnit(
+		  required date   dt
+		, required string unit
+		, required string direction
+	) {
+		var floored = _floorToUnit( arguments.dt, arguments.unit );
+
+		if ( arguments.direction == "ceil" ) {
+			return DateAdd( "s", -1, DateAdd( _toDateAddPart( arguments.unit ), 1, floored ) );
+		}
+
+		return floored;
+	}
+
+	private date function _floorToUnit( required date dt, required string unit ) {
+		if ( !Compare( arguments.unit, "M" ) ) {
+			return CreateDateTime( Year( arguments.dt ), Month( arguments.dt ), 1, 0, 0, 0 );
+		}
+
+		switch( arguments.unit ) {
+			case "s":
+				return CreateDateTime(
+					  Year( arguments.dt )
+					, Month( arguments.dt )
+					, Day( arguments.dt )
+					, Hour( arguments.dt )
+					, Minute( arguments.dt )
+					, Second( arguments.dt )
+				);
+			case "m":
+				return CreateDateTime(
+					  Year( arguments.dt )
+					, Month( arguments.dt )
+					, Day( arguments.dt )
+					, Hour( arguments.dt )
+					, Minute( arguments.dt )
+					, 0
+				);
+			case "h":
+				return CreateDateTime(
+					  Year( arguments.dt )
+					, Month( arguments.dt )
+					, Day( arguments.dt )
+					, Hour( arguments.dt )
+					, 0
+					, 0
+				);
+			case "d":
+				return CreateDateTime(
+					  Year( arguments.dt )
+					, Month( arguments.dt )
+					, Day( arguments.dt )
+					, 0
+					, 0
+					, 0
+				);
+			case "w":
+				return _floorToStartOfWeek( arguments.dt );
+			case "y":
+				return CreateDateTime( Year( arguments.dt ), 1, 1, 0, 0, 0 );
+		}
+
+		_throwInvalid( arguments.unit );
+	}
+
+	private date function _floorToStartOfWeek( required date dt ) {
+		var dayOfWeek      = DayOfWeek( arguments.dt );
+		var daysFromMonday = dayOfWeek == 1 ? 6 : dayOfWeek - 2;
+		var monday         = DateAdd( "d", -daysFromMonday, arguments.dt );
+
+		return CreateDateTime( Year( monday ), Month( monday ), Day( monday ), 0, 0, 0 );
+	}
+
+}

--- a/tests/BaseTest.cfc
+++ b/tests/BaseTest.cfc
@@ -342,8 +342,9 @@ component extends="testbox.system.BaseSpec" {
 		presideRestService.$( "extractTokensFromUri" ).$results( arguments.restTokens );
 
 		var svc = createMock( object=new dataApi.services.DataApiService(
-			  presideRestService = presideRestService
-			, configService      = configService
+			  presideRestService            = presideRestService
+			, configService                 = configService
+			, relativeDateExpressionService = new dataApi.services.RelativeDateExpressionService()
 		) );
 
 		return _wirePresideStubs( svc, namespace, {}, i18nBundle );

--- a/tests/fixtures/DataApiTestFixtures.cfc
+++ b/tests/fixtures/DataApiTestFixtures.cfc
@@ -10,6 +10,7 @@ component {
 					, dataApiCategory       = "crm"
 					, dataApiQueueEnabled   = true
 					, dataApiQueue          = "default"
+					, dataApiFilterFields   = "datemodified,datecreated,is_active,status"
 					, dbFieldlist           = "id,label,datemodified,datecreated,is_active,status"
 				  }
 				, properties = {

--- a/tests/unit/DataApiServiceTest.cfc
+++ b/tests/unit/DataApiServiceTest.cfc
@@ -274,6 +274,90 @@ component extends="tests.BaseTest" {
 				expect( result ).toBe( "" );
 			} );
 		} );
+
+		describe( "date filter resolution", function(){
+			it( "should resolve relative date expressions in min and max filters", function(){
+				var configSvc    = _getConfigService();
+				var svc          = _getDataApiService( configSvc );
+				var capturedArgs = [];
+				var dao          = _mockPresideObject( "test_contact" );
+
+				dao.$( "selectData" ).$callback( function() {
+					ArrayAppend( capturedArgs, Duplicate( arguments ) );
+					if ( ArrayLen( capturedArgs ) == 1 ) {
+						return [ { id=CreateUUID(), label="One", datemodified=Now(), datecreated=Now(), is_active=true, status="" } ];
+					}
+					return 1;
+				} );
+				svc.$( "$getPresideObject" ).$args( "test_contact" ).$results( dao );
+
+				svc.getPaginatedRecords(
+					  entity   = "contact"
+					, page     = 1
+					, pageSize = 10
+					, fields   = []
+					, filters  = { "datemodified.min"="now-7d", "datemodified.max"="now" }
+				);
+
+				expect( ArrayLen( capturedArgs ) ).toBeGT( 0 );
+				expect( ArrayLen( capturedArgs[ 1 ].extraFilters ?: [] ) ).toBe( 2 );
+
+				var minValue = capturedArgs[ 1 ].extraFilters[ 1 ].filterParams.datemodified__min.value;
+				var maxValue = capturedArgs[ 1 ].extraFilters[ 2 ].filterParams.datemodified__max.value;
+
+				expect( minValue ).notToBe( "now-7d" );
+				expect( maxValue ).notToBe( "now" );
+				expect( IsDate( minValue ) ).toBeTrue();
+				expect( IsDate( maxValue ) ).toBeTrue();
+				expect( Abs( DateDiff( "s", ParseDateTime( minValue ), DateAdd( "d", -7, Now() ) ) ) ).toBeLTE( 2 );
+				expect( Abs( DateDiff( "s", ParseDateTime( maxValue ), Now() ) ) ).toBeLTE( 2 );
+			} );
+
+			it( "should leave absolute date filter values unchanged", function(){
+				var configSvc    = _getConfigService();
+				var svc          = _getDataApiService( configSvc );
+				var capturedArgs = [];
+				var dao          = _mockPresideObject( "test_contact" );
+
+				dao.$( "selectData" ).$callback( function() {
+					ArrayAppend( capturedArgs, Duplicate( arguments ) );
+					if ( ArrayLen( capturedArgs ) == 1 ) {
+						return [ { id=CreateUUID(), label="One", datemodified=Now(), datecreated=Now(), is_active=true, status="" } ];
+					}
+					return 1;
+				} );
+				svc.$( "$getPresideObject" ).$args( "test_contact" ).$results( dao );
+
+				svc.getPaginatedRecords(
+					  entity   = "contact"
+					, page     = 1
+					, pageSize = 10
+					, fields   = []
+					, filters  = { "datemodified.min"="2024-01-01" }
+				);
+
+				expect( ArrayLen( capturedArgs ) ).toBeGT( 0 );
+				expect( capturedArgs[ 1 ].extraFilters[ 1 ].filterParams.datemodified__min.value ).toBe( "2024-01-01" );
+			} );
+
+			it( "should throw for invalid relative date expressions", function(){
+				var configSvc = _getConfigService();
+				var svc       = _getDataApiService( configSvc );
+				var dao       = _mockPresideObject( "test_contact" );
+
+				svc.$( "$getPresideObject" ).$args( "test_contact" ).$results( dao );
+
+				expect( function(){
+					svc.getPaginatedRecords(
+						  entity   = "contact"
+						, page     = 1
+						, pageSize = 10
+						, fields   = []
+						, filters  = { "datemodified.min"="now-7x" }
+					);
+				} ).toThrow( type="dataApi.relativeDate.invalid" );
+			} );
+		} );
 	}
 
 }

--- a/tests/unit/RelativeDateExpressionServiceTest.cfc
+++ b/tests/unit/RelativeDateExpressionServiceTest.cfc
@@ -1,0 +1,104 @@
+component extends="tests.BaseTest" {
+
+	function run() {
+		describe( "isRelativeExpression()", function(){
+			it( "should recognise Grafana-style relative expressions", function(){
+				var svc = _getService();
+
+				expect( svc.isRelativeExpression( "now" ) ).toBeTrue();
+				expect( svc.isRelativeExpression( "Now-7d" ) ).toBeTrue();
+				expect( svc.isRelativeExpression( "now+1h" ) ).toBeTrue();
+				expect( svc.isRelativeExpression( "now/d" ) ).toBeTrue();
+				expect( svc.isRelativeExpression( "now-1d/d" ) ).toBeTrue();
+			} );
+
+			it( "should reject absolute dates and unrelated values", function(){
+				var svc = _getService();
+
+				expect( svc.isRelativeExpression( "2024-01-01" ) ).toBeFalse();
+				expect( svc.isRelativeExpression( "nowhere" ) ).toBeFalse();
+				expect( svc.isRelativeExpression( "" ) ).toBeFalse();
+			} );
+		} );
+
+		describe( "parse()", function(){
+			it( "should return the reference date for now", function(){
+				var svc      = _getService();
+				var refDate  = CreateDateTime( 2024, 6, 15, 14, 30, 45 );
+				var resolved = svc.parse( expression="now", referenceDate=refDate );
+
+				expect( DateCompare( resolved, refDate ) ).toBe( 0 );
+			} );
+
+			it( "should apply day hour and month offsets", function(){
+				var svc     = _getService();
+				var refDate = CreateDateTime( 2024, 6, 15, 14, 30, 45 );
+
+				expect( DateCompare( svc.parse( expression="now-7d", referenceDate=refDate ), CreateDateTime( 2024, 6, 8, 14, 30, 45 ) ) ).toBe( 0 );
+				expect( DateCompare( svc.parse( expression="now-1h", referenceDate=refDate ), CreateDateTime( 2024, 6, 15, 13, 30, 45 ) ) ).toBe( 0 );
+				expect( DateCompare( svc.parse( expression="now+1M", referenceDate=refDate ), CreateDateTime( 2024, 7, 15, 14, 30, 45 ) ) ).toBe( 0 );
+				expect( DateCompare( svc.parse( expression="now-30m", referenceDate=refDate ), CreateDateTime( 2024, 6, 15, 14, 0, 45 ) ) ).toBe( 0 );
+			} );
+
+			it( "should be case-insensitive for the now token", function(){
+				var svc     = _getService();
+				var refDate = CreateDateTime( 2024, 6, 15, 14, 30, 45 );
+
+				expect( DateCompare( svc.parse( expression="Now-7d", referenceDate=refDate ), CreateDateTime( 2024, 6, 8, 14, 30, 45 ) ) ).toBe( 0 );
+				expect( DateCompare( svc.parse( expression="NOW-7d", referenceDate=refDate ), CreateDateTime( 2024, 6, 8, 14, 30, 45 ) ) ).toBe( 0 );
+			} );
+
+			it( "should floor to the start of a unit", function(){
+				var svc     = _getService();
+				var refDate = CreateDateTime( 2024, 6, 15, 14, 30, 45 );
+
+				expect( DateCompare( svc.parse( expression="now/d", roundDirection="floor", referenceDate=refDate ), CreateDateTime( 2024, 6, 15, 0, 0, 0 ) ) ).toBe( 0 );
+				expect( DateCompare( svc.parse( expression="now/h", roundDirection="floor", referenceDate=refDate ), CreateDateTime( 2024, 6, 15, 14, 0, 0 ) ) ).toBe( 0 );
+				expect( DateCompare( svc.parse( expression="now/M", roundDirection="floor", referenceDate=refDate ), CreateDateTime( 2024, 6, 1, 0, 0, 0 ) ) ).toBe( 0 );
+			} );
+
+			it( "should ceil to the end of a unit for max bounds", function(){
+				var svc     = _getService();
+				var refDate = CreateDateTime( 2024, 6, 15, 14, 30, 45 );
+
+				expect( DateCompare( svc.parse( expression="now/d", roundDirection="ceil", referenceDate=refDate ), CreateDateTime( 2024, 6, 15, 23, 59, 59 ) ) ).toBe( 0 );
+				expect( DateCompare( svc.parse( expression="now/h", roundDirection="ceil", referenceDate=refDate ), CreateDateTime( 2024, 6, 15, 14, 59, 59 ) ) ).toBe( 0 );
+			} );
+
+			it( "should apply offset then floor", function(){
+				var svc     = _getService();
+				var refDate = CreateDateTime( 2024, 6, 15, 14, 30, 45 );
+
+				expect( DateCompare( svc.parse( expression="now-1d/d", roundDirection="floor", referenceDate=refDate ), CreateDateTime( 2024, 6, 14, 0, 0, 0 ) ) ).toBe( 0 );
+			} );
+
+			it( "should floor weeks to Monday", function(){
+				var svc     = _getService();
+				var saturday = CreateDateTime( 2024, 6, 15, 14, 30, 45 );
+
+				expect( DateCompare( svc.parse( expression="now/w", roundDirection="floor", referenceDate=saturday ), CreateDateTime( 2024, 6, 10, 0, 0, 0 ) ) ).toBe( 0 );
+			} );
+
+			it( "should throw for malformed relative expressions", function(){
+				var svc = _getService();
+
+				expect( function(){
+					svc.parse( expression="now-7x" );
+				} ).toThrow( type="dataApi.relativeDate.invalid" );
+
+				expect( function(){
+					svc.parse( expression="now/q" );
+				} ).toThrow( type="dataApi.relativeDate.invalid" );
+
+				expect( function(){
+					svc.parse( expression="now-7d/extra" );
+				} ).toThrow( type="dataApi.relativeDate.invalid" );
+			} );
+		} );
+	}
+
+	private any function _getService() {
+		return new dataApi.services.RelativeDateExpressionService();
+	}
+
+}


### PR DESCRIPTION
Support relative dates for our min/max date filters. e.g.

`?filter.datecreated.min=now-7d`

README + OpenAPI Swagger Docs updated to include documentation of this.